### PR TITLE
feat(engine): build trace engine and compliance snapshot

### DIFF
--- a/docs/objective_mapping.md
+++ b/docs/objective_mapping.md
@@ -1,0 +1,60 @@
+# Objective Mapping Rules
+
+The objective mapper evaluates every DO-178C objective against the evidence that
+was imported from adapters. Each objective declares a list of artifact types
+(e.g. `psac`, `testResults`) that must be satisfied. The mapper inspects the
+bundle's `evidenceIndex` and assigns a coverage status according to the
+following rules:
+
+| Condition | Status | Notes |
+| --- | --- | --- |
+| All required artifact types have at least one matching evidence entry | `covered` | Evidence references are recorded as `<artifactType>:<path>` strings. |
+| At least one artifact type is supported but others are missing | `partial` | Gap analysis will list the missing artifact types in their respective category (plan, standard, test, coverage). |
+| None of the required artifact types are satisfied | `missing` | The objective is reported as missing and will appear in gap analysis buckets. |
+
+## Example
+
+Consider the following fragment from an `ImportBundle`:
+
+```ts
+const bundle = {
+  objectives: [
+    {
+      id: 'A-Verification-Obj1',
+      area: 'Verification',
+      description: 'Verify implementation with tests and coverage.',
+      artifacts: ['testResults', 'coverage'],
+      level: { A: true, B: false, C: false, D: false, E: false },
+    },
+  ],
+  evidenceIndex: {
+    testResults: [
+      { source: 'junit', path: 'reports/junit.xml', summary: 'Test execution', timestamp: '2024-01-10T10:00:00Z' },
+    ],
+    coverage: [
+      { source: 'lcov', path: 'reports/lcov.info', summary: 'Statement coverage', timestamp: '2024-01-10T10:00:00Z' },
+    ],
+  },
+};
+```
+
+When the mapper processes this input it produces the following
+`ObjectiveCoverage` entry:
+
+```json
+{
+  "objectiveId": "A-Verification-Obj1",
+  "status": "covered",
+  "evidenceRefs": [
+    "testResults:reports/junit.xml",
+    "coverage:reports/lcov.info"
+  ],
+  "satisfiedArtifacts": ["testResults", "coverage"],
+  "missingArtifacts": []
+}
+```
+
+If the coverage artifact was absent, the status would change to `partial`, and
+`missingArtifacts` would include `coverage`. This information feeds the gap
+analysis, which groups missing artifacts by the plan, standard, test, and
+coverage categories that stakeholders expect in DO-178C assessments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8058,6 +8058,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@soipack/adapters": "0.1.0",
         "@soipack/core": "0.1.0"
       }
     },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "@soipack/adapters": "0.1.0",
     "@soipack/core": "0.1.0"
   },
   "scripts": {

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,32 +1,255 @@
-import { createRequirement, TestCase } from '@soipack/core';
+import { CoverageSummary, TestResult } from '@soipack/adapters';
+import {
+  Evidence,
+  Objective,
+  ObjectiveArtifactType,
+  Requirement,
+  TraceLink,
+  createRequirement,
+} from '@soipack/core';
 
-import { buildTraceMatrix, createTraceLink } from './index';
+import { ImportBundle, ObjectiveMapper, TraceEngine, generateComplianceSnapshot } from './index';
 
-describe('@soipack/engine', () => {
-  const requirement = createRequirement('REQ-10', 'Authenticate user');
-  const test: TestCase = {
-    id: 'TC-1',
-    name: 'should authenticate with valid credentials',
-    requirementId: requirement.id,
-    status: 'pending',
-  };
+const evidence = (type: ObjectiveArtifactType, path: string, source: Evidence['source']): Evidence => ({
+  source,
+  path,
+  summary: `${type} evidence`,
+  timestamp: '2024-01-10T10:00:00Z',
+});
 
-  it('creates trace link with precision', () => {
-    const link = createTraceLink(requirement, test, 0.876);
-    expect(link.confidence).toBe(0.88);
+const requirementFixture = (): Requirement[] => [
+  createRequirement('REQ-1', 'Authenticate user', { status: 'implemented' }),
+  createRequirement('REQ-2', 'Lock account after failures', { status: 'approved' }),
+  createRequirement('REQ-3', 'Audit login attempts', { status: 'draft' }),
+];
+
+const coverageFixture = (): CoverageSummary => ({
+  totals: {
+    statements: { covered: 80, total: 100, percentage: 80 },
+    branches: { covered: 30, total: 50, percentage: 60 },
+    functions: { covered: 12, total: 20, percentage: 60 },
+  },
+  files: [
+    {
+      file: 'src/auth/login.ts',
+      statements: { covered: 30, total: 40, percentage: 75 },
+      branches: { covered: 10, total: 16, percentage: 62.5 },
+      functions: { covered: 5, total: 6, percentage: 83.33 },
+    },
+    {
+      file: 'src/common/logger.ts',
+      statements: { covered: 20, total: 20, percentage: 100 },
+      functions: { covered: 3, total: 3, percentage: 100 },
+    },
+  ],
+});
+
+const testResultsFixture = (): TestResult[] => [
+  {
+    testId: 'TC-1',
+    className: 'AuthSuite',
+    name: 'should authenticate valid users',
+    status: 'passed',
+    duration: 12,
+    requirementsRefs: ['REQ-1'],
+  },
+  {
+    testId: 'TC-2',
+    className: 'AuthSuite',
+    name: 'should reject locked users',
+    status: 'failed',
+    duration: 15,
+    requirementsRefs: ['REQ-1', 'REQ-2'],
+  },
+  {
+    testId: 'TC-3',
+    className: 'AuditSuite',
+    name: 'should record failed login attempts',
+    status: 'passed',
+    duration: 8,
+    requirementsRefs: ['REQ-2'],
+  },
+  {
+    testId: 'TC-4',
+    className: 'AuditSuite',
+    name: 'should send audit notifications',
+    status: 'skipped',
+    duration: 5,
+  },
+];
+
+const level = { A: true, B: false, C: false, D: false, E: false } as const;
+
+const objectivesFixture = (): Objective[] => [
+  {
+    id: 'A-Plans-Obj1',
+    area: 'Plans',
+    description: 'Ensure PSAC baseline is established.',
+    artifacts: ['psac'],
+    level,
+  },
+  {
+    id: 'A-Plans-Obj2',
+    area: 'Plans',
+    description: 'Ensure SDP and PSAC consistency.',
+    artifacts: ['psac', 'sdp'],
+    level,
+  },
+  {
+    id: 'A-Verification-Obj1',
+    area: 'Verification',
+    description: 'Verify implementation with tests and coverage.',
+    artifacts: ['testResults', 'coverage'],
+    level,
+  },
+  {
+    id: 'A-Verification-Obj2',
+    area: 'Verification',
+    description: 'Trace tests back to requirements.',
+    artifacts: ['testResults', 'traceability'],
+    level,
+  },
+  {
+    id: 'A-Standards-Obj1',
+    area: 'Standards',
+    description: 'Maintain configuration index with plans.',
+    artifacts: ['configurationIndex', 'sdp'],
+    level,
+  },
+  {
+    id: 'A-Reviews-Obj1',
+    area: 'Reviews',
+    description: 'Perform peer reviews for life cycle data.',
+    artifacts: ['analysisReport'],
+    level,
+  },
+  {
+    id: 'A-Reviews-Obj2',
+    area: 'Reviews',
+    description: 'Audit configuration baselines.',
+    artifacts: ['git'],
+    level,
+  },
+];
+
+const evidenceIndexFixture = () => ({
+  psac: [evidence('psac', 'plans/psac.md', 'git')],
+  sdp: [evidence('sdp', 'plans/sdp.md', 'git')],
+  testResults: [evidence('testResults', 'reports/junit.xml', 'junit')],
+  coverage: [evidence('coverage', 'reports/lcov.info', 'lcov')],
+});
+
+const traceLinksFixture = (): TraceLink[] => [
+  { from: 'REQ-3', to: 'TC-4', type: 'verifies' },
+];
+
+const bundleFixture = (): ImportBundle => ({
+  requirements: requirementFixture(),
+  objectives: objectivesFixture(),
+  testResults: testResultsFixture(),
+  coverage: coverageFixture(),
+  evidenceIndex: evidenceIndexFixture(),
+  traceLinks: traceLinksFixture(),
+  testToCodeMap: {
+    'TC-1': ['src/auth/login.ts'],
+    'TC-2': ['src/common/logger.ts'],
+    'TC-3': ['src/auth/login.ts'],
+    'TC-4': ['src/common/logger.ts'],
+  },
+  generatedAt: '2024-02-01T10:00:00Z',
+});
+
+describe('TraceEngine', () => {
+  const bundle = bundleFixture();
+  const engine = new TraceEngine(bundle);
+
+  it('links requirements to their related tests and code paths', () => {
+    const trace = engine.getRequirementTrace('REQ-1');
+    expect(trace.tests.map((test) => test.testId)).toEqual(
+      expect.arrayContaining(['TC-1', 'TC-2']),
+    );
+    const codePaths = trace.code.map((item) => item.path);
+    expect(codePaths).toEqual(
+      expect.arrayContaining(['src/auth/login.ts', 'src/common/logger.ts']),
+    );
+
+    const loginCoverage = trace.code.find((item) => item.path === 'src/auth/login.ts');
+    expect(loginCoverage?.coverage?.statements.covered).toBe(30);
   });
 
-  it('builds trace matrix grouped by requirement', () => {
-    const matrix = buildTraceMatrix([
-      createTraceLink(requirement, test, 0.9),
-      createTraceLink(requirement, { ...test, id: 'TC-2' }, 0.75),
+  it('incorporates trace links when tests lack explicit requirement references', () => {
+    const trace = engine.getRequirementTrace('REQ-3');
+    expect(trace.tests.map((test) => test.testId)).toContain('TC-4');
+  });
+});
+
+describe('ObjectiveMapper', () => {
+  const bundle = bundleFixture();
+  const mapper = new ObjectiveMapper(bundle.objectives, bundle.evidenceIndex);
+  const coverage = mapper.mapObjectives();
+
+  it('returns coverage summaries for each objective', () => {
+    const statuses = new Map(coverage.map((item) => [item.objectiveId, item.status]));
+    expect(statuses.get('A-Plans-Obj1')).toBe('covered');
+    expect(statuses.get('A-Plans-Obj2')).toBe('covered');
+    expect(statuses.get('A-Verification-Obj1')).toBe('covered');
+    expect(statuses.get('A-Verification-Obj2')).toBe('partial');
+    expect(statuses.get('A-Standards-Obj1')).toBe('partial');
+    expect(statuses.get('A-Reviews-Obj1')).toBe('missing');
+    expect(statuses.get('A-Reviews-Obj2')).toBe('missing');
+  });
+
+  it('collects evidence references for satisfied artifacts', () => {
+    const plansObjective = coverage.find((item) => item.objectiveId === 'A-Plans-Obj2');
+    expect(plansObjective?.evidenceRefs).toEqual(
+      expect.arrayContaining(['psac:plans/psac.md', 'sdp:plans/sdp.md']),
+    );
+  });
+});
+
+describe('Compliance snapshot generation', () => {
+  const bundle = bundleFixture();
+  const snapshot = generateComplianceSnapshot(bundle);
+
+  it('summarizes objective coverage and statistics', () => {
+    expect(snapshot.objectives).toHaveLength(7);
+    expect(snapshot.stats.objectives).toEqual({
+      total: 7,
+      covered: 3,
+      partial: 2,
+      missing: 2,
+    });
+
+    expect(snapshot.stats.tests).toEqual({ total: 4, passed: 2, failed: 1, skipped: 1 });
+    expect(snapshot.stats.requirements).toEqual({ total: 3 });
+    expect(snapshot.stats.codePaths).toEqual({ total: 2 });
+  });
+
+  it('derives gap analysis grouped by artifact category', () => {
+    expect(snapshot.gaps.tests).toEqual([
+      { objectiveId: 'A-Verification-Obj2', missingArtifacts: ['traceability'] },
     ]);
 
-    expect(matrix).toEqual([
-      {
-        requirementId: 'REQ-10',
-        testCaseIds: ['TC-1', 'TC-2'],
-      },
-    ]);
+    expect(snapshot.gaps.standards).toEqual(
+      expect.arrayContaining([
+        { objectiveId: 'A-Standards-Obj1', missingArtifacts: ['configurationIndex'] },
+        { objectiveId: 'A-Reviews-Obj1', missingArtifacts: ['analysisReport'] },
+        { objectiveId: 'A-Reviews-Obj2', missingArtifacts: ['git'] },
+      ]),
+    );
+
+    expect(snapshot.gaps.coverage).toHaveLength(0);
+    expect(snapshot.gaps.plans).toHaveLength(0);
+  });
+
+  it('exposes trace graph nodes for requirements, tests, and code paths', () => {
+    const types = snapshot.traceGraph.nodes.reduce<Record<string, number>>((acc, node) => {
+      acc[node.type] = (acc[node.type] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    expect(types.requirement).toBe(3);
+    expect(types.test).toBe(4);
+    expect(types.code).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- implement a traceability engine that links requirements, test results, and LCOV code paths and emits compliance snapshots with statistics
- add an objective mapper that classifies DO-178C objectives into covered/partial/missing states and groups gap analysis by artifact category
- document objective mapping rules for evidence indexing and reporting consumers

## Testing
- npm test -- packages/engine

------
https://chatgpt.com/codex/tasks/task_b_68ce706f016c8328bcc22346ad0544f7