### PR TITLE
feat(report): add compliance reporting suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -544,6 +544,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -1271,6 +1295,34 @@
       "resolved": "packages/server",
       "link": true
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1462,6 +1514,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -1759,6 +1818,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1793,6 +1858,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1880,6 +1958,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2030,7 +2115,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -2564,6 +2648,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -2652,6 +2745,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2856,6 +2956,16 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -5941,6 +6051,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -6344,6 +6479,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7483,6 +7662,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -7759,6 +7982,13 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -8000,6 +8230,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8068,7 +8308,13 @@
       "license": "MIT",
       "dependencies": {
         "@soipack/core": "0.1.0",
-        "@soipack/engine": "0.1.0"
+        "@soipack/engine": "0.1.0",
+        "nunjucks": "^3.2.4",
+        "playwright": "^1.41.2"
+      },
+      "devDependencies": {
+        "@types/nunjucks": "^3.2.6",
+        "ts-node": "^10.9.2"
       }
     },
     "packages/server": {

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -7,10 +7,17 @@
   "license": "MIT",
   "dependencies": {
     "@soipack/core": "0.1.0",
-    "@soipack/engine": "0.1.0"
+    "@soipack/engine": "0.1.0",
+    "nunjucks": "^3.2.4",
+    "playwright": "^1.41.2"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "test": "jest --config ./jest.config.cjs"
+    "test": "jest --config ./jest.config.cjs",
+    "demo": "node -r ts-node/register src/demo.ts"
+  },
+  "devDependencies": {
+    "@types/nunjucks": "^3.2.6",
+    "ts-node": "^10.9.2"
   }
 }

--- a/packages/report/src/__fixtures__/goldens/compliance-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/compliance-matrix.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kurumsal Uyum Matrisi</title>
+    <style>
+      
+  :root {
+    color-scheme: light;
+    font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: #f3f5f9;
+    color: #0f172a;
+  }
+
+  .report-header {
+    background: linear-gradient(135deg, #0f172a, #1d2b64);
+    color: #f8fafc;
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .report-header h1 {
+    margin: 0 0 8px;
+    font-size: 28px;
+    font-weight: 600;
+  }
+
+  .report-meta {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.9;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  .summary-card {
+    background: rgba(15, 23, 42, 0.35);
+    border-radius: 12px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .summary-card strong {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  main {
+    padding: 32px 48px 48px;
+  }
+
+  .section {
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+    padding: 24px 28px;
+    margin-bottom: 32px;
+  }
+
+  .section h2 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #1e293b;
+  }
+
+  .section-lead {
+    color: #475569;
+    margin-bottom: 16px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th {
+    text-align: left;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #475569;
+    border-bottom: 2px solid #e2e8f0;
+    padding: 12px;
+  }
+
+  td {
+    border-bottom: 1px solid #e2e8f0;
+    padding: 14px 12px;
+    vertical-align: top;
+  }
+
+  .cell-title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .cell-subtitle {
+    font-size: 13px;
+    color: #334155;
+    margin-top: 4px;
+  }
+
+  .cell-description {
+    color: #475569;
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    background: #e2e8f0;
+    color: #0f172a;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .badge-soft {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .badge-critical {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .status-covered {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .status-partial {
+    background: #fef9c3;
+    color: #854d0e;
+  }
+
+  .status-missing {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .muted {
+    color: #64748b;
+    font-size: 13px;
+  }
+
+  .list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+  }
+
+  .code-pill {
+    display: inline-block;
+    padding: 4px 10px;
+    background: #eef2ff;
+    color: #312e81;
+    border-radius: 8px;
+    font-size: 12px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .gap-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .gap-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    min-height: 180px;
+  }
+
+  .gap-card h3 {
+    margin-top: 0;
+    font-size: 16px;
+    color: #1e293b;
+  }
+
+  footer {
+    padding: 0 48px 32px;
+    color: #475569;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @media print {
+    body {
+      background: #ffffff;
+    }
+
+    footer {
+      display: none;
+    }
+  }
+
+      @page {
+        margin: 25mm 20mm;
+        size: A4;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="report-header">
+      <div>
+        <h1>Kurumsal Uyum Matrisi</h1>
+        
+          <p class="report-meta">Denetlenebilir uyum için kanıt özet matrisi</p>
+        
+        <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
+        <p class="report-meta">Rapor Tarihi: 2024-02-01 12:00 UTC</p>
+      </div>
+      <div class="summary-grid">
+        
+          <div class="summary-card">
+            <span>Hedefler</span>
+            <strong>4</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Tamamlanan</span>
+            <strong>1</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Kısmi</span>
+            <strong>3</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Eksik</span>
+            <strong>0</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Testler</span>
+            <strong>4</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Kod Yolları</span>
+            <strong>2</strong>
+          </div>
+        
+      </div>
+    </header>
+    <main>
+      <section class="section">
+    <h2>Uyum Matrisi</h2>
+    <p class="section-lead">
+      Hedeflerin kanıt durumunu gösteren kurumsal görünüm. Her satır bir uyumluluk hedefini, sağlanan kanıtları ve açık kalan boşlukları özetler.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Hedef</th>
+          <th>Durum</th>
+          <th>Sağlanan Kanıtlar</th>
+          <th>Eksik Kanıtlar</th>
+          <th>Kanıt Referansları</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          <tr>
+            <td>
+              <div class="cell-title">OBJ-PLAN-1</div>
+              
+                <div class="cell-subtitle">Plans</div>
+              
+              
+                <div class="cell-description">PSAC ve SDP tutarlılığı doğrulanmalı.</div>
+              
+            </td>
+            <td><span class="badge status-partial">Kısmen Karşılandı</span></td>
+            <td>
+              
+                
+                  <span class="badge badge-soft">PSAC</span>
+                
+              
+            </td>
+            <td>
+              
+                
+                  <span class="badge badge-critical">SDP</span>
+                
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li class="muted">psac:docs/psac-v1.pdf</li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+          <tr>
+            <td>
+              <div class="cell-title">OBJ-VER-1</div>
+              
+                <div class="cell-subtitle">Verification</div>
+              
+              
+                <div class="cell-description">Test sonuçları ve izlenebilirlik kanıtlanmalı.</div>
+              
+            </td>
+            <td><span class="badge status-partial">Kısmen Karşılandı</span></td>
+            <td>
+              
+                
+                  <span class="badge badge-soft">Test Sonuçları</span>
+                
+              
+            </td>
+            <td>
+              
+                
+                  <span class="badge badge-critical">İzlenebilirlik</span>
+                
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li class="muted">testResults:reports/junit.xml</li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+          <tr>
+            <td>
+              <div class="cell-title">OBJ-VER-2</div>
+              
+                <div class="cell-subtitle">Verification</div>
+              
+              
+                <div class="cell-description">Kod kapsamı düzenli olarak izlenmeli.</div>
+              
+            </td>
+            <td><span class="badge status-covered">Tam Karşılandı</span></td>
+            <td>
+              
+                
+                  <span class="badge badge-soft">Kod Kapsamı</span>
+                
+              
+            </td>
+            <td>
+              
+                <span class="muted">Eksik kanıt yok</span>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li class="muted">coverage:reports/coverage-summary.json</li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+          <tr>
+            <td>
+              <div class="cell-title">OBJ-STND-1</div>
+              
+                <div class="cell-subtitle">Standards</div>
+              
+              
+                <div class="cell-description">Konfigürasyon indeksinin güncelliği izlenmeli.</div>
+              
+            </td>
+            <td><span class="badge status-partial">Kısmen Karşılandı</span></td>
+            <td>
+              
+                
+                  <span class="badge badge-soft">Sürüm Kontrol</span>
+                
+              
+            </td>
+            <td>
+              
+                
+                  <span class="badge badge-critical">Konfigürasyon İndeksi</span>
+                
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li class="muted">git:git://repo#main</li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+      </tbody>
+    </table>
+  </section>
+    </main>
+    <footer>
+      <span>SOIPack Sürüm 0.1.0</span>
+      <span>Sayfa numarası PDF çıktısında görüntülenecektir.</span>
+    </footer>
+  </body>
+</html>

--- a/packages/report/src/__fixtures__/goldens/gaps.html
+++ b/packages/report/src/__fixtures__/goldens/gaps.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Uyum Boşlukları</title>
+    <style>
+      
+  :root {
+    color-scheme: light;
+    font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: #f3f5f9;
+    color: #0f172a;
+  }
+
+  .report-header {
+    background: linear-gradient(135deg, #0f172a, #1d2b64);
+    color: #f8fafc;
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .report-header h1 {
+    margin: 0 0 8px;
+    font-size: 28px;
+    font-weight: 600;
+  }
+
+  .report-meta {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.9;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  .summary-card {
+    background: rgba(15, 23, 42, 0.35);
+    border-radius: 12px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .summary-card strong {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  main {
+    padding: 32px 48px 48px;
+  }
+
+  .section {
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+    padding: 24px 28px;
+    margin-bottom: 32px;
+  }
+
+  .section h2 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #1e293b;
+  }
+
+  .section-lead {
+    color: #475569;
+    margin-bottom: 16px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th {
+    text-align: left;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #475569;
+    border-bottom: 2px solid #e2e8f0;
+    padding: 12px;
+  }
+
+  td {
+    border-bottom: 1px solid #e2e8f0;
+    padding: 14px 12px;
+    vertical-align: top;
+  }
+
+  .cell-title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .cell-subtitle {
+    font-size: 13px;
+    color: #334155;
+    margin-top: 4px;
+  }
+
+  .cell-description {
+    color: #475569;
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    background: #e2e8f0;
+    color: #0f172a;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .badge-soft {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .badge-critical {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .status-covered {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .status-partial {
+    background: #fef9c3;
+    color: #854d0e;
+  }
+
+  .status-missing {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .muted {
+    color: #64748b;
+    font-size: 13px;
+  }
+
+  .list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+  }
+
+  .code-pill {
+    display: inline-block;
+    padding: 4px 10px;
+    background: #eef2ff;
+    color: #312e81;
+    border-radius: 8px;
+    font-size: 12px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .gap-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .gap-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    min-height: 180px;
+  }
+
+  .gap-card h3 {
+    margin-top: 0;
+    font-size: 16px;
+    color: #1e293b;
+  }
+
+  footer {
+    padding: 0 48px 32px;
+    color: #475569;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @media print {
+    body {
+      background: #ffffff;
+    }
+
+    footer {
+      display: none;
+    }
+  }
+
+      @page {
+        margin: 25mm 20mm;
+        size: A4;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="report-header">
+      <div>
+        <h1>Uyum Boşlukları</h1>
+        
+          <p class="report-meta">Kanıt eksikliği bulunan alanların özet görünümü</p>
+        
+        <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
+        <p class="report-meta">Rapor Tarihi: 2024-02-01 12:00 UTC</p>
+      </div>
+      <div class="summary-grid">
+        
+          <div class="summary-card">
+            <span>Plan Boşlukları</span>
+            <strong>1</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Standart Boşlukları</span>
+            <strong>1</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Test Boşlukları</span>
+            <strong>1</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Kapsam Boşlukları</span>
+            <strong>0</strong>
+          </div>
+        
+      </div>
+    </header>
+    <main>
+      <section class="section">
+    <h2>Uyum Boşlukları</h2>
+    <p class="section-lead">
+      Kanıt eksikliklerini kategori bazında gösterir. Boşluklar denetim öncesi tamamlanması gereken alanları belirtir.
+    </p>
+    <div class="gap-grid">
+      
+        <article class="gap-card">
+          <h3>Planlama Kanıtları</h3>
+          
+            <ul class="list">
+              
+                <li>
+                  <div class="cell-title">OBJ-PLAN-1</div>
+                  
+                    <div class="cell-subtitle">Plans</div>
+                  
+                  
+                    <div class="cell-description">PSAC ve SDP tutarlılığı doğrulanmalı.</div>
+                  
+                  <div>
+                    
+                      <span class="badge badge-critical">SDP</span>
+                    
+                  </div>
+                </li>
+              
+            </ul>
+          
+        </article>
+      
+        <article class="gap-card">
+          <h3>Standart &amp; Konfigürasyon</h3>
+          
+            <ul class="list">
+              
+                <li>
+                  <div class="cell-title">OBJ-STND-1</div>
+                  
+                    <div class="cell-subtitle">Standards</div>
+                  
+                  
+                    <div class="cell-description">Konfigürasyon indeksinin güncelliği izlenmeli.</div>
+                  
+                  <div>
+                    
+                      <span class="badge badge-critical">Konfigürasyon İndeksi</span>
+                    
+                  </div>
+                </li>
+              
+            </ul>
+          
+        </article>
+      
+        <article class="gap-card">
+          <h3>Test Kanıtları</h3>
+          
+            <ul class="list">
+              
+                <li>
+                  <div class="cell-title">OBJ-VER-1</div>
+                  
+                    <div class="cell-subtitle">Verification</div>
+                  
+                  
+                    <div class="cell-description">Test sonuçları ve izlenebilirlik kanıtlanmalı.</div>
+                  
+                  <div>
+                    
+                      <span class="badge badge-critical">İzlenebilirlik</span>
+                    
+                  </div>
+                </li>
+              
+            </ul>
+          
+        </article>
+      
+        <article class="gap-card">
+          <h3>Kapsam Kanıtları</h3>
+          
+            <p class="muted">Boşluk tespit edilmedi.</p>
+          
+        </article>
+      
+    </div>
+  </section>
+    </main>
+    <footer>
+      <span>SOIPack Sürüm 0.1.0</span>
+      <span>Sayfa numarası PDF çıktısında görüntülenecektir.</span>
+    </footer>
+  </body>
+</html>

--- a/packages/report/src/__fixtures__/goldens/trace-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/trace-matrix.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kurumsal İzlenebilirlik Matrisi</title>
+    <style>
+      
+  :root {
+    color-scheme: light;
+    font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: #f3f5f9;
+    color: #0f172a;
+  }
+
+  .report-header {
+    background: linear-gradient(135deg, #0f172a, #1d2b64);
+    color: #f8fafc;
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .report-header h1 {
+    margin: 0 0 8px;
+    font-size: 28px;
+    font-weight: 600;
+  }
+
+  .report-meta {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.9;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  .summary-card {
+    background: rgba(15, 23, 42, 0.35);
+    border-radius: 12px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .summary-card strong {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  main {
+    padding: 32px 48px 48px;
+  }
+
+  .section {
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+    padding: 24px 28px;
+    margin-bottom: 32px;
+  }
+
+  .section h2 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #1e293b;
+  }
+
+  .section-lead {
+    color: #475569;
+    margin-bottom: 16px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th {
+    text-align: left;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #475569;
+    border-bottom: 2px solid #e2e8f0;
+    padding: 12px;
+  }
+
+  td {
+    border-bottom: 1px solid #e2e8f0;
+    padding: 14px 12px;
+    vertical-align: top;
+  }
+
+  .cell-title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .cell-subtitle {
+    font-size: 13px;
+    color: #334155;
+    margin-top: 4px;
+  }
+
+  .cell-description {
+    color: #475569;
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    background: #e2e8f0;
+    color: #0f172a;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .badge-soft {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .badge-critical {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .status-covered {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .status-partial {
+    background: #fef9c3;
+    color: #854d0e;
+  }
+
+  .status-missing {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .muted {
+    color: #64748b;
+    font-size: 13px;
+  }
+
+  .list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+  }
+
+  .code-pill {
+    display: inline-block;
+    padding: 4px 10px;
+    background: #eef2ff;
+    color: #312e81;
+    border-radius: 8px;
+    font-size: 12px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .gap-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .gap-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    min-height: 180px;
+  }
+
+  .gap-card h3 {
+    margin-top: 0;
+    font-size: 16px;
+    color: #1e293b;
+  }
+
+  footer {
+    padding: 0 48px 32px;
+    color: #475569;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @media print {
+    body {
+      background: #ffffff;
+    }
+
+    footer {
+      display: none;
+    }
+  }
+
+      @page {
+        margin: 25mm 20mm;
+        size: A4;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="report-header">
+      <div>
+        <h1>Kurumsal İzlenebilirlik Matrisi</h1>
+        
+          <p class="report-meta">Gereksinim → Test → Kod eşleşmelerinin kurumsal görünümü</p>
+        
+        <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
+        <p class="report-meta">Rapor Tarihi: 2025-09-20 09:46 UTC</p>
+      </div>
+      <div class="summary-grid">
+        
+          <div class="summary-card">
+            <span>Gereksinimler</span>
+            <strong>3</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Bağlı Testler</span>
+            <strong>5</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Kod İzleri</span>
+            <strong>4</strong>
+          </div>
+        
+      </div>
+    </header>
+    <main>
+      <section class="section">
+    <h2>İzlenebilirlik Matrisi</h2>
+    <p class="section-lead">
+      Gereksinimlerin testler ve kod yolları ile eşleşmesini gösteren izlenebilirlik tablosu. Denetlenebilirliği sağlamak için kanıt zincirini ortaya koyar.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Gereksinim</th>
+          <th>Test Kanıtları</th>
+          <th>Kod Yolları</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          <tr>
+            <td>
+              <div class="cell-title">REQ-AUTH-1</div>
+              <div class="cell-description">Çok faktörlü giriş sağlamalı</div>
+              
+                <div class="muted">Durum: approved</div>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li>
+                      <span class="badge status-covered">Başarılı</span>
+                      <div class="cell-title">geçerli kullanıcı giriş yapabilmeli</div>
+                      <div class="muted">TC-LOGIN-1</div>
+                    </li>
+                  
+                    <li>
+                      <span class="badge status-missing">Başarısız</span>
+                      <div class="cell-title">başarısız girişler kilitlenmeli</div>
+                      <div class="muted">TC-LOGIN-2</div>
+                    </li>
+                  
+                </ul>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li>
+                      <code class="code-pill">src/auth/login.ts</code>
+                      
+                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80%</div>
+                      
+                    </li>
+                  
+                    <li>
+                      <code class="code-pill">src/security/audit.ts</code>
+                      
+                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50%</div>
+                      
+                    </li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+          <tr>
+            <td>
+              <div class="cell-title">REQ-AUTH-2</div>
+              <div class="cell-description">Başarısız girişler kaydedilmeli</div>
+              
+                <div class="muted">Durum: implemented</div>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li>
+                      <span class="badge status-missing">Başarısız</span>
+                      <div class="cell-title">başarısız girişler kilitlenmeli</div>
+                      <div class="muted">TC-LOGIN-2</div>
+                    </li>
+                  
+                    <li>
+                      <span class="badge status-covered">Başarılı</span>
+                      <div class="cell-title">denetim kayıtları oluşturulmalı</div>
+                      <div class="muted">TC-AUDIT-1</div>
+                    </li>
+                  
+                </ul>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li>
+                      <code class="code-pill">src/auth/login.ts</code>
+                      
+                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80%</div>
+                      
+                    </li>
+                  
+                    <li>
+                      <code class="code-pill">src/security/audit.ts</code>
+                      
+                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50%</div>
+                      
+                    </li>
+                  
+                </ul>
+              
+            </td>
+          </tr>
+        
+          <tr>
+            <td>
+              <div class="cell-title">REQ-AUTH-3</div>
+              <div class="cell-description">Giriş ihlallerinde uyarı gönderilmeli</div>
+              
+                <div class="muted">Durum: draft</div>
+              
+            </td>
+            <td>
+              
+                <ul class="list">
+                  
+                    <li>
+                      <span class="badge status-partial">Atlandı</span>
+                      <div class="cell-title">uyarı bildirimleri gönderilmeli</div>
+                      <div class="muted">TC-AUDIT-2</div>
+                    </li>
+                  
+                </ul>
+              
+            </td>
+            <td>
+              
+                <span class="muted">Kod bağlantısı yok</span>
+              
+            </td>
+          </tr>
+        
+      </tbody>
+    </table>
+  </section>
+    </main>
+    <footer>
+      <span>SOIPack Sürüm 0.1.0</span>
+      <span>Sayfa numarası PDF çıktısında görüntülenecektir.</span>
+    </footer>
+  </body>
+</html>

--- a/packages/report/src/__fixtures__/snapshot.ts
+++ b/packages/report/src/__fixtures__/snapshot.ts
@@ -1,0 +1,186 @@
+import { CoverageSummary, TestResult } from '@soipack/adapters';
+import {
+  Evidence,
+  EvidenceSource,
+  Objective,
+  ObjectiveArtifactType,
+  createRequirement,
+} from '@soipack/core';
+import {
+  ComplianceSnapshot,
+  ImportBundle,
+  RequirementTrace,
+  TraceEngine,
+  generateComplianceSnapshot,
+} from '@soipack/engine';
+
+export interface ReportFixture {
+  snapshot: ComplianceSnapshot;
+  traces: RequirementTrace[];
+  objectives: Objective[];
+  manifestId: string;
+}
+
+const level = { A: true, B: false, C: false, D: false, E: false } as const;
+
+const evidenceSourceMap: Partial<Record<ObjectiveArtifactType, EvidenceSource>> = {
+  testResults: 'junit',
+  coverage: 'lcov',
+  git: 'git',
+};
+
+const buildEvidence = (
+  artifact: ObjectiveArtifactType,
+  path: string,
+  summary: string,
+): Evidence => ({
+  source: evidenceSourceMap[artifact] ?? 'other',
+  path,
+  summary,
+  timestamp: '2024-01-10T09:30:00Z',
+});
+
+const coverageFixture = (): CoverageSummary => ({
+  totals: {
+    statements: { covered: 55, total: 80, percentage: 68.75 },
+    branches: { covered: 22, total: 40, percentage: 55 },
+    functions: { covered: 18, total: 24, percentage: 75 },
+  },
+  files: [
+    {
+      file: 'src/auth/login.ts',
+      statements: { covered: 28, total: 32, percentage: 87.5 },
+      branches: { covered: 12, total: 16, percentage: 75 },
+      functions: { covered: 8, total: 10, percentage: 80 },
+    },
+    {
+      file: 'src/security/audit.ts',
+      statements: { covered: 16, total: 32, percentage: 50 },
+      branches: { covered: 6, total: 12, percentage: 50 },
+      functions: { covered: 4, total: 8, percentage: 50 },
+    },
+  ],
+});
+
+const testResultsFixture = (): TestResult[] => [
+  {
+    testId: 'TC-LOGIN-1',
+    className: 'AuthenticationFlow',
+    name: 'geçerli kullanıcı giriş yapabilmeli',
+    status: 'passed',
+    duration: 12,
+    requirementsRefs: ['REQ-AUTH-1'],
+  },
+  {
+    testId: 'TC-LOGIN-2',
+    className: 'AuthenticationFlow',
+    name: 'başarısız girişler kilitlenmeli',
+    status: 'failed',
+    duration: 14,
+    requirementsRefs: ['REQ-AUTH-1', 'REQ-AUTH-2'],
+  },
+  {
+    testId: 'TC-AUDIT-1',
+    className: 'AuditFlow',
+    name: 'denetim kayıtları oluşturulmalı',
+    status: 'passed',
+    duration: 9,
+    requirementsRefs: ['REQ-AUTH-2'],
+  },
+  {
+    testId: 'TC-AUDIT-2',
+    className: 'AuditFlow',
+    name: 'uyarı bildirimleri gönderilmeli',
+    status: 'skipped',
+    duration: 7,
+    requirementsRefs: ['REQ-AUTH-3'],
+  },
+];
+
+const objectivesFixture = (): Objective[] => [
+  {
+    id: 'OBJ-PLAN-1',
+    area: 'Plans',
+    description: 'PSAC ve SDP tutarlılığı doğrulanmalı.',
+    artifacts: ['psac', 'sdp'],
+    level,
+  },
+  {
+    id: 'OBJ-VER-1',
+    area: 'Verification',
+    description: 'Test sonuçları ve izlenebilirlik kanıtlanmalı.',
+    artifacts: ['testResults', 'traceability'],
+    level,
+  },
+  {
+    id: 'OBJ-VER-2',
+    area: 'Verification',
+    description: 'Kod kapsamı düzenli olarak izlenmeli.',
+    artifacts: ['coverage'],
+    level,
+  },
+  {
+    id: 'OBJ-STND-1',
+    area: 'Standards',
+    description: 'Konfigürasyon indeksinin güncelliği izlenmeli.',
+    artifacts: ['configurationIndex', 'git'],
+    level,
+  },
+];
+
+const requirementFixture = () => [
+  createRequirement('REQ-AUTH-1', 'Çok faktörlü giriş sağlamalı', {
+    status: 'approved',
+    tags: ['security', 'auth'],
+  }),
+  createRequirement('REQ-AUTH-2', 'Başarısız girişler kaydedilmeli', {
+    status: 'implemented',
+    tags: ['audit'],
+  }),
+  createRequirement('REQ-AUTH-3', 'Giriş ihlallerinde uyarı gönderilmeli', {
+    status: 'draft',
+    tags: ['alerting'],
+  }),
+];
+
+const evidenceFixture = (): ImportBundle['evidenceIndex'] => ({
+  psac: [buildEvidence('psac', 'docs/psac-v1.pdf', 'PSAC onayı')],
+  sdp: [],
+  testResults: [buildEvidence('testResults', 'reports/junit.xml', 'JUnit sonuçları')],
+  traceability: [],
+  coverage: [buildEvidence('coverage', 'reports/coverage-summary.json', 'İstanbul kapsama özeti')],
+  configurationIndex: [],
+  git: [buildEvidence('git', 'git://repo#main', 'Git commit referansı')],
+});
+
+export const createReportFixture = (): ReportFixture => {
+  const requirements = requirementFixture();
+  const objectives = objectivesFixture();
+  const testResults = testResultsFixture();
+  const coverage = coverageFixture();
+  const evidenceIndex = evidenceFixture();
+  const bundle: ImportBundle = {
+    requirements,
+    objectives,
+    testResults,
+    coverage,
+    evidenceIndex,
+    testToCodeMap: {
+      'TC-LOGIN-1': ['src/auth/login.ts'],
+      'TC-LOGIN-2': ['src/auth/login.ts', 'src/security/audit.ts'],
+      'TC-AUDIT-1': ['src/security/audit.ts'],
+    },
+    generatedAt: '2024-02-01T12:00:00Z',
+  };
+
+  const snapshot = generateComplianceSnapshot(bundle);
+  const engine = new TraceEngine(bundle);
+  const traces = requirements.map((requirement) => engine.getRequirementTrace(requirement.id));
+
+  return {
+    snapshot,
+    traces,
+    objectives,
+    manifestId: 'MAN-TR-2024-0001',
+  };
+};

--- a/packages/report/src/demo.ts
+++ b/packages/report/src/demo.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { renderComplianceMatrix, renderGaps, renderTraceMatrix, printToPDF } from './index';
+import { createReportFixture } from './__fixtures__/snapshot';
+
+const main = async (): Promise<void> => {
+  const fixture = createReportFixture();
+  const outputDir = path.resolve(__dirname, '..', 'dist', 'reports');
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const compliance = renderComplianceMatrix(fixture.snapshot, {
+    manifestId: fixture.manifestId,
+    objectivesMetadata: fixture.objectives,
+    title: 'SOIPack Kurumsal Uyum Matrisi',
+  });
+
+  await fs.writeFile(path.join(outputDir, 'compliance-matrix.html'), compliance.html, 'utf-8');
+  await fs.writeFile(
+    path.join(outputDir, 'compliance-matrix.json'),
+    JSON.stringify(compliance.json, null, 2),
+    'utf-8',
+  );
+
+  const traceHtml = renderTraceMatrix(fixture.traces, {
+    manifestId: fixture.manifestId,
+    title: 'SOIPack İzlenebilirlik Matrisi',
+  });
+  await fs.writeFile(path.join(outputDir, 'trace-matrix.html'), traceHtml, 'utf-8');
+
+  const gapsHtml = renderGaps(fixture.snapshot, {
+    manifestId: fixture.manifestId,
+    objectivesMetadata: fixture.objectives,
+    title: 'SOIPack Uyum Boşlukları',
+  });
+  await fs.writeFile(path.join(outputDir, 'gaps.html'), gapsHtml, 'utf-8');
+
+  const pdfBuffer = await printToPDF(compliance.html, {
+    manifestId: fixture.manifestId,
+    generatedAt: fixture.snapshot.generatedAt,
+  });
+  await fs.writeFile(path.join(outputDir, 'compliance-matrix.pdf'), pdfBuffer);
+
+  // eslint-disable-next-line no-console
+  console.log(`Reports generated at ${outputDir}`);
+};
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to generate demo reports:', error);
+  process.exitCode = 1;
+});

--- a/packages/report/src/index.test.ts
+++ b/packages/report/src/index.test.ts
@@ -1,57 +1,151 @@
-import { createRequirement, TestCase } from '@soipack/core';
-import { buildTraceMatrix, createTraceLink } from '@soipack/engine';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
-import { generatePdf, renderHtmlReport, renderJsonReport } from './index';
+import { createRequirement, TestCase } from '@soipack/core';
+
+import {
+  HtmlReportOptions,
+  renderComplianceMatrix,
+  renderGaps,
+  renderHtmlReport,
+  renderJsonReport,
+  renderTraceMatrix,
+  printToPDF,
+} from './index';
+import { createReportFixture } from './__fixtures__/snapshot';
+
+type PlaywrightModule = typeof import('playwright');
 
 describe('@soipack/report', () => {
-  const requirement = createRequirement('REQ-1', 'Secure login', {
-    status: 'approved',
-    tags: ['security'],
-  });
-  const testCase: TestCase = {
-    id: 'TC-1',
-    name: 'should request 2FA',
-    requirementId: 'REQ-1',
-    status: 'pending',
-  };
-  const matrix = buildTraceMatrix([createTraceLink(requirement, testCase, 0.9)]);
+  const goldenDir = path.resolve(__dirname, '__fixtures__', 'goldens');
+  const sanitizeHtml = (value: string): string => value.replace(/>\s+</g, '><').replace(/\s{2,}/g, ' ').trim();
+  const hashHtml = (value: string): string => createHash('sha256').update(sanitizeHtml(value)).digest('hex');
 
-  it('renders HTML table with requirement and tests', () => {
-    const html = renderHtmlReport(matrix, [requirement], [testCase], {
-      title: 'Custom Report',
+  it('renders compliance matrix with JSON payload', () => {
+    const fixture = createReportFixture();
+    const result = renderComplianceMatrix(fixture.snapshot, {
+      manifestId: fixture.manifestId,
+      objectivesMetadata: fixture.objectives,
+      title: 'Kurumsal Uyum Matrisi',
     });
 
-    expect(html).toContain('<h1>Custom Report</h1>');
-    expect(html).toContain('Secure login');
-    expect(html).toContain('should request 2FA');
+    expect(result.json.manifestId).toBe(fixture.manifestId);
+    expect(result.json.stats).toEqual(fixture.snapshot.stats);
+    expect(result.json.objectives).toHaveLength(fixture.snapshot.objectives.length);
+
+    const goldenHtml = readFileSync(path.join(goldenDir, 'compliance-matrix.html'), 'utf-8');
+    expect(hashHtml(result.html)).toBe(hashHtml(goldenHtml));
+    expect(result.html).toContain('Kanıt Manifest ID');
   });
 
-  it('builds JSON report with metadata', () => {
+  it('renders trace matrix with trace information', () => {
+    const fixture = createReportFixture();
+    const html = renderTraceMatrix(fixture.traces, {
+      manifestId: fixture.manifestId,
+      title: 'Kurumsal İzlenebilirlik Matrisi',
+    });
+
+    const goldenHtml = readFileSync(path.join(goldenDir, 'trace-matrix.html'), 'utf-8');
+    expect(hashHtml(html)).toBe(hashHtml(goldenHtml));
+    expect(html).toContain('Gereksinim → Test → Kod');
+  });
+
+  it('renders gap analysis with objective metadata', () => {
+    const fixture = createReportFixture();
+    const html = renderGaps(fixture.snapshot, {
+      manifestId: fixture.manifestId,
+      objectivesMetadata: fixture.objectives,
+      title: 'Uyum Boşlukları',
+    });
+
+    const goldenHtml = readFileSync(path.join(goldenDir, 'gaps.html'), 'utf-8');
+    expect(hashHtml(html)).toBe(hashHtml(goldenHtml));
+    expect(html).toContain('Boşluk');
+  });
+
+  it('prints PDF using Playwright with metadata in header and footer', async () => {
+    const pdfBuffer = Buffer.from('pdf');
+    const html = '<html><body><main>report</main></body></html>';
+    const actions: string[] = [];
+
+    const pageStub = {
+      async setContent(content: string) {
+        actions.push('setContent');
+        expect(content).toBe(html);
+      },
+      async pdf(options: any) {
+        actions.push('pdf');
+        expect(options.format).toBe('A4');
+        expect(options.displayHeaderFooter).toBe(true);
+        expect(options.headerTemplate).toContain('Sürüm 9.9.9');
+        expect(options.footerTemplate).toContain('MANIFEST-001');
+        return pdfBuffer;
+      },
+      async close() {
+        actions.push('pageClose');
+      },
+    };
+
+    const browserStub = {
+      async newPage() {
+        actions.push('newPage');
+        return pageStub;
+      },
+      async close() {
+        actions.push('browserClose');
+      },
+    };
+
+    const playwrightStub = {
+      chromium: {
+        async launch() {
+          actions.push('launch');
+          return browserStub;
+        },
+      },
+    } as unknown as PlaywrightModule;
+
+    await expect(
+      printToPDF(html, {
+        playwright: playwrightStub,
+        version: '9.9.9',
+        manifestId: 'MANIFEST-001',
+        generatedAt: '2024-02-01T12:00:00Z',
+      }),
+    ).resolves.toBe(pdfBuffer);
+
+    expect(actions).toEqual(['launch', 'newPage', 'setContent', 'pdf', 'pageClose', 'browserClose']);
+  });
+
+  it('keeps legacy HTML and JSON helpers for CLI', () => {
+    const requirement = createRequirement('REQ-1', 'Secure login', {
+      status: 'approved',
+      tags: ['security'],
+    });
+    const testCase: TestCase = {
+      id: 'TC-1',
+      name: 'should request 2FA',
+      requirementId: 'REQ-1',
+      status: 'pending',
+    };
+
+    const matrix = [{ requirementId: requirement.id, testCaseIds: [testCase.id] }];
+
+    const html = renderHtmlReport(matrix, [requirement], [testCase], {
+      title: 'Custom Report',
+    } satisfies HtmlReportOptions);
     const json = renderJsonReport(matrix, [requirement], [testCase]);
 
+    expect(html).toContain('<h1>Custom Report</h1>');
     expect(json).toEqual({
       generatedAt: expect.any(String),
       requirements: [
         {
-          requirement: requirement,
+          requirement,
           tests: [testCase],
         },
       ],
     });
-  });
-
-  it('generates PDF using a provided page implementation', async () => {
-    const html = renderHtmlReport(matrix, [requirement], [testCase]);
-    const pdfBuffer = Buffer.from('pdf');
-    const stub = {
-      async setContent(content: string) {
-        expect(content).toBe(html);
-      },
-      async pdf() {
-        return pdfBuffer;
-      },
-    };
-
-    await expect(generatePdf(stub, html)).resolves.toBe(pdfBuffer);
   });
 });

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -1,6 +1,831 @@
-import { Requirement, TestCase } from '@soipack/core';
-import { TraceMatrix } from '@soipack/engine';
+import { Objective, ObjectiveArtifactType, Requirement, TestCase } from '@soipack/core';
+import { ComplianceSnapshot, ComplianceStatistics, RequirementTrace } from '@soipack/engine';
+import nunjucks from 'nunjucks';
+import type { Browser, Page } from 'playwright';
+import packageInfo from '../package.json';
 
+type PlaywrightModule = typeof import('playwright');
+
+type GapCategoryKey = keyof ComplianceSnapshot['gaps'];
+
+interface LayoutSummaryMetric {
+  label: string;
+  value: string;
+  accent?: boolean;
+}
+
+interface BaseReportOptions {
+  title?: string;
+  manifestId?: string;
+  generatedAt?: string;
+  version?: string;
+}
+
+interface LayoutContext extends BaseReportOptions {
+  summaryMetrics: LayoutSummaryMetric[];
+  subtitle?: string;
+  content: string;
+}
+
+export interface ComplianceMatrixOptions extends BaseReportOptions {
+  objectivesMetadata?: Objective[];
+}
+
+export interface TraceMatrixOptions extends BaseReportOptions {}
+
+export interface GapReportOptions extends BaseReportOptions {
+  objectivesMetadata?: Objective[];
+}
+
+interface ComplianceMatrixRow {
+  id: string;
+  status: ComplianceSnapshot['objectives'][number]['status'];
+  statusLabel: string;
+  statusClass: string;
+  description?: string;
+  area?: string;
+  satisfiedArtifacts: string[];
+  missingArtifacts: string[];
+  evidenceRefs: string[];
+}
+
+interface TraceMatrixRow {
+  requirementId: string;
+  requirementTitle: string;
+  requirementStatus?: Requirement['status'];
+  tests: Array<{
+    id: string;
+    name: string;
+    statusLabel: string;
+    statusClass: string;
+  }>;
+  codePaths: Array<{
+    path: string;
+    coverageLabel?: string;
+  }>;
+}
+
+interface GapReportRow {
+  objectiveId: string;
+  description?: string;
+  area?: string;
+  missingArtifacts: string[];
+}
+
+export interface ComplianceMatrixJson {
+  manifestId?: string;
+  generatedAt: string;
+  version: string;
+  stats: ComplianceStatistics;
+  objectives: Array<{
+    id: string;
+    status: ComplianceSnapshot['objectives'][number]['status'];
+    description?: string;
+    area?: string;
+    satisfiedArtifacts: string[];
+    missingArtifacts: string[];
+    evidenceRefs: string[];
+  }>;
+}
+
+export interface ComplianceMatrixResult {
+  html: string;
+  json: ComplianceMatrixJson;
+}
+
+export interface PrintToPdfOptions extends BaseReportOptions {
+  playwright?: PlaywrightModule;
+  margin?: {
+    top?: string;
+    bottom?: string;
+    left?: string;
+    right?: string;
+  };
+}
+
+const env = new nunjucks.Environment(undefined, { autoescape: true });
+
+const statusLabels: Record<ComplianceSnapshot['objectives'][number]['status'], string> = {
+  covered: 'Tam Karşılandı',
+  partial: 'Kısmen Karşılandı',
+  missing: 'Eksik',
+};
+
+const testStatusLabels: Record<string, { label: string; className: string }> = {
+  passed: { label: 'Başarılı', className: 'status-covered' },
+  failed: { label: 'Başarısız', className: 'status-missing' },
+  skipped: { label: 'Atlandı', className: 'status-partial' },
+};
+
+const gapLabels: Record<GapCategoryKey, string> = {
+  plans: 'Planlama Kanıtları',
+  standards: 'Standart & Konfigürasyon',
+  tests: 'Test Kanıtları',
+  coverage: 'Kapsam Kanıtları',
+};
+
+const gapSummaryLabels: Record<GapCategoryKey, string> = {
+  plans: 'Plan Boşlukları',
+  standards: 'Standart Boşlukları',
+  tests: 'Test Boşlukları',
+  coverage: 'Kapsam Boşlukları',
+};
+
+const artifactLabels: Partial<Record<ObjectiveArtifactType, string>> = {
+  psac: 'PSAC',
+  sdp: 'SDP',
+  svr: 'SVR',
+  testResults: 'Test Sonuçları',
+  coverage: 'Kod Kapsamı',
+  traceability: 'İzlenebilirlik',
+  analysisReport: 'Analiz Raporu',
+  configurationIndex: 'Konfigürasyon İndeksi',
+  git: 'Sürüm Kontrol',
+  other: 'Diğer',
+};
+
+const baseStyles = `
+  :root {
+    color-scheme: light;
+    font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: #f3f5f9;
+    color: #0f172a;
+  }
+
+  .report-header {
+    background: linear-gradient(135deg, #0f172a, #1d2b64);
+    color: #f8fafc;
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .report-header h1 {
+    margin: 0 0 8px;
+    font-size: 28px;
+    font-weight: 600;
+  }
+
+  .report-meta {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.9;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  .summary-card {
+    background: rgba(15, 23, 42, 0.35);
+    border-radius: 12px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .summary-card strong {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  main {
+    padding: 32px 48px 48px;
+  }
+
+  .section {
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+    padding: 24px 28px;
+    margin-bottom: 32px;
+  }
+
+  .section h2 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #1e293b;
+  }
+
+  .section-lead {
+    color: #475569;
+    margin-bottom: 16px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th {
+    text-align: left;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #475569;
+    border-bottom: 2px solid #e2e8f0;
+    padding: 12px;
+  }
+
+  td {
+    border-bottom: 1px solid #e2e8f0;
+    padding: 14px 12px;
+    vertical-align: top;
+  }
+
+  .cell-title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .cell-subtitle {
+    font-size: 13px;
+    color: #334155;
+    margin-top: 4px;
+  }
+
+  .cell-description {
+    color: #475569;
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    background: #e2e8f0;
+    color: #0f172a;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .badge-soft {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .badge-critical {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .status-covered {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .status-partial {
+    background: #fef9c3;
+    color: #854d0e;
+  }
+
+  .status-missing {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .muted {
+    color: #64748b;
+    font-size: 13px;
+  }
+
+  .list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+  }
+
+  .code-pill {
+    display: inline-block;
+    padding: 4px 10px;
+    background: #eef2ff;
+    color: #312e81;
+    border-radius: 8px;
+    font-size: 12px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+  }
+
+  .gap-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .gap-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    min-height: 180px;
+  }
+
+  .gap-card h3 {
+    margin-top: 0;
+    font-size: 16px;
+    color: #1e293b;
+  }
+
+  footer {
+    padding: 0 48px 32px;
+    color: #475569;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @media print {
+    body {
+      background: #ffffff;
+    }
+
+    footer {
+      display: none;
+    }
+  }
+`;
+
+const layoutTemplate = nunjucks.compile(
+  `<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+    <style>
+      ${baseStyles}
+      @page {
+        margin: 25mm 20mm;
+        size: A4;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="report-header">
+      <div>
+        <h1>{{ title }}</h1>
+        {% if subtitle %}
+          <p class="report-meta">{{ subtitle }}</p>
+        {% endif %}
+        <p class="report-meta">Kanıt Manifest ID: <strong>{{ manifestId or 'N/A' }}</strong></p>
+        <p class="report-meta">Rapor Tarihi: {{ generatedAt }}</p>
+      </div>
+      <div class="summary-grid">
+        {% for metric in summaryMetrics %}
+          <div class="summary-card">
+            <span>{{ metric.label }}</span>
+            <strong>{{ metric.value }}</strong>
+          </div>
+        {% endfor %}
+      </div>
+    </header>
+    <main>
+      {{ content | safe }}
+    </main>
+    <footer>
+      <span>SOIPack Sürüm {{ version }}</span>
+      <span>Sayfa numarası PDF çıktısında görüntülenecektir.</span>
+    </footer>
+  </body>
+</html>`,
+  env,
+);
+
+const complianceTemplate = nunjucks.compile(
+  `<section class="section">
+    <h2>Uyum Matrisi</h2>
+    <p class="section-lead">
+      Hedeflerin kanıt durumunu gösteren kurumsal görünüm. Her satır bir uyumluluk hedefini, sağlanan kanıtları ve açık kalan boşlukları özetler.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Hedef</th>
+          <th>Durum</th>
+          <th>Sağlanan Kanıtlar</th>
+          <th>Eksik Kanıtlar</th>
+          <th>Kanıt Referansları</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in objectives %}
+          <tr>
+            <td>
+              <div class="cell-title">{{ row.id }}</div>
+              {% if row.area %}
+                <div class="cell-subtitle">{{ row.area }}</div>
+              {% endif %}
+              {% if row.description %}
+                <div class="cell-description">{{ row.description }}</div>
+              {% endif %}
+            </td>
+            <td><span class="badge {{ row.statusClass }}">{{ row.statusLabel }}</span></td>
+            <td>
+              {% if row.satisfiedArtifacts.length %}
+                {% for artifact in row.satisfiedArtifacts %}
+                  <span class="badge badge-soft">{{ artifact }}</span>
+                {% endfor %}
+              {% else %}
+                <span class="muted">Kanıt bulunmuyor</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if row.missingArtifacts.length %}
+                {% for artifact in row.missingArtifacts %}
+                  <span class="badge badge-critical">{{ artifact }}</span>
+                {% endfor %}
+              {% else %}
+                <span class="muted">Eksik kanıt yok</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if row.evidenceRefs.length %}
+                <ul class="list">
+                  {% for reference in row.evidenceRefs %}
+                    <li class="muted">{{ reference }}</li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <span class="muted">Referans bulunmuyor</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>`,
+  env,
+);
+
+const traceTemplate = nunjucks.compile(
+  `<section class="section">
+    <h2>İzlenebilirlik Matrisi</h2>
+    <p class="section-lead">
+      Gereksinimlerin testler ve kod yolları ile eşleşmesini gösteren izlenebilirlik tablosu. Denetlenebilirliği sağlamak için kanıt zincirini ortaya koyar.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Gereksinim</th>
+          <th>Test Kanıtları</th>
+          <th>Kod Yolları</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+          <tr>
+            <td>
+              <div class="cell-title">{{ row.requirementId }}</div>
+              <div class="cell-description">{{ row.requirementTitle }}</div>
+              {% if row.requirementStatus %}
+                <div class="muted">Durum: {{ row.requirementStatus }}</div>
+              {% endif %}
+            </td>
+            <td>
+              {% if row.tests.length %}
+                <ul class="list">
+                  {% for test in row.tests %}
+                    <li>
+                      <span class="badge {{ test.statusClass }}">{{ test.statusLabel }}</span>
+                      <div class="cell-title">{{ test.name }}</div>
+                      <div class="muted">{{ test.id }}</div>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <span class="muted">Test kaydı yok</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if row.codePaths.length %}
+                <ul class="list">
+                  {% for code in row.codePaths %}
+                    <li>
+                      <code class="code-pill">{{ code.path }}</code>
+                      {% if code.coverageLabel %}
+                        <div class="muted">{{ code.coverageLabel }}</div>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <span class="muted">Kod bağlantısı yok</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>`,
+  env,
+);
+
+const gapsTemplate = nunjucks.compile(
+  `<section class="section">
+    <h2>Uyum Boşlukları</h2>
+    <p class="section-lead">
+      Kanıt eksikliklerini kategori bazında gösterir. Boşluklar denetim öncesi tamamlanması gereken alanları belirtir.
+    </p>
+    <div class="gap-grid">
+      {% for category in categories %}
+        <article class="gap-card">
+          <h3>{{ category.label }}</h3>
+          {% if category.items.length %}
+            <ul class="list">
+              {% for item in category.items %}
+                <li>
+                  <div class="cell-title">{{ item.objectiveId }}</div>
+                  {% if item.area %}
+                    <div class="cell-subtitle">{{ item.area }}</div>
+                  {% endif %}
+                  {% if item.description %}
+                    <div class="cell-description">{{ item.description }}</div>
+                  {% endif %}
+                  <div>
+                    {% for artifact in item.missingArtifacts %}
+                      <span class="badge badge-critical">{{ artifact }}</span>
+                    {% endfor %}
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="muted">Boşluk tespit edilmedi.</p>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+  </section>`,
+  env,
+);
+
+const formatDate = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const [isoDate, isoTime] = date.toISOString().split('T');
+  const time = isoTime.slice(0, 5);
+  return `${isoDate} ${time} UTC`;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatArtifact = (artifact: ObjectiveArtifactType): string =>
+  artifactLabels[artifact] ?? artifact.toUpperCase();
+
+const buildSummaryMetrics = (stats: ComplianceStatistics): LayoutSummaryMetric[] => [
+  { label: 'Hedefler', value: stats.objectives.total.toString() },
+  { label: 'Tamamlanan', value: stats.objectives.covered.toString() },
+  { label: 'Kısmi', value: stats.objectives.partial.toString() },
+  { label: 'Eksik', value: stats.objectives.missing.toString() },
+  { label: 'Testler', value: stats.tests.total.toString() },
+  { label: 'Kod Yolları', value: stats.codePaths.total.toString() },
+];
+
+const renderLayout = (context: LayoutContext): string => {
+  const version = context.version ?? packageInfo.version;
+  return layoutTemplate.render({
+    ...context,
+    generatedAt: formatDate(context.generatedAt ?? new Date().toISOString()),
+    version,
+  });
+};
+
+export const renderComplianceMatrix = (
+  snapshot: ComplianceSnapshot,
+  options: ComplianceMatrixOptions = {},
+): ComplianceMatrixResult => {
+  const objectiveLookup = new Map(options.objectivesMetadata?.map((item) => [item.id, item]));
+
+  const rows: ComplianceMatrixRow[] = snapshot.objectives.map((objective) => {
+    const metadata = objectiveLookup.get(objective.objectiveId);
+    return {
+      id: objective.objectiveId,
+      status: objective.status,
+      statusLabel: statusLabels[objective.status],
+      statusClass:
+        objective.status === 'covered'
+          ? 'status-covered'
+          : objective.status === 'partial'
+            ? 'status-partial'
+            : 'status-missing',
+      description: metadata?.description,
+      area: metadata?.area,
+      satisfiedArtifacts: objective.satisfiedArtifacts.map(formatArtifact),
+      missingArtifacts: objective.missingArtifacts.map(formatArtifact),
+      evidenceRefs: objective.evidenceRefs,
+    };
+  });
+
+  const html = renderLayout({
+    title: options.title ?? 'SOIPack Uyum Matrisi',
+    manifestId: options.manifestId ?? 'N/A',
+    generatedAt: options.generatedAt ?? snapshot.generatedAt,
+    version: options.version ?? packageInfo.version,
+    summaryMetrics: buildSummaryMetrics(snapshot.stats),
+    content: complianceTemplate.render({ objectives: rows }),
+    subtitle: 'Denetlenebilir uyum için kanıt özet matrisi',
+  });
+
+  const json: ComplianceMatrixJson = {
+    manifestId: options.manifestId,
+    generatedAt: options.generatedAt ?? snapshot.generatedAt,
+    version: options.version ?? packageInfo.version,
+    stats: {
+      objectives: { ...snapshot.stats.objectives },
+      requirements: { ...snapshot.stats.requirements },
+      tests: { ...snapshot.stats.tests },
+      codePaths: { ...snapshot.stats.codePaths },
+    },
+    objectives: rows.map((row) => ({
+      id: row.id,
+      status: row.status,
+      description: row.description,
+      area: row.area,
+      satisfiedArtifacts: [...row.satisfiedArtifacts],
+      missingArtifacts: [...row.missingArtifacts],
+      evidenceRefs: [...row.evidenceRefs],
+    })),
+  };
+
+  return { html, json };
+};
+
+export const renderTraceMatrix = (
+  trace: RequirementTrace[],
+  options: TraceMatrixOptions = {},
+): string => {
+  const rows: TraceMatrixRow[] = trace.map((item) => ({
+    requirementId: item.requirement.id,
+    requirementTitle: item.requirement.title,
+    requirementStatus: item.requirement.status,
+    tests: item.tests.map((test) => {
+      const meta = testStatusLabels[test.status] ?? { label: test.status ?? 'Bilinmiyor', className: 'badge-soft' };
+      return {
+        id: test.testId,
+        name: test.name ?? test.testId,
+        statusLabel: meta.label,
+        statusClass: meta.className,
+      };
+    }),
+    codePaths: item.code.map((code) => {
+      const statements = code.coverage?.statements?.percentage;
+      const branches = code.coverage?.branches?.percentage;
+      const functions = code.coverage?.functions?.percentage;
+      const coverageSegments: string[] = [];
+      if (typeof statements === 'number') {
+        coverageSegments.push(`Satır: ${statements}%`);
+      }
+      if (typeof branches === 'number') {
+        coverageSegments.push(`Dallanma: ${branches}%`);
+      }
+      if (typeof functions === 'number') {
+        coverageSegments.push(`Fonksiyon: ${functions}%`);
+      }
+      return {
+        path: code.path,
+        coverageLabel: coverageSegments.length ? coverageSegments.join(' | ') : undefined,
+      };
+    }),
+  }));
+
+  const summaryMetrics: LayoutSummaryMetric[] = [
+    { label: 'Gereksinimler', value: rows.length.toString() },
+    {
+      label: 'Bağlı Testler',
+      value: rows.reduce((acc, row) => acc + row.tests.length, 0).toString(),
+    },
+    {
+      label: 'Kod İzleri',
+      value: rows.reduce((acc, row) => acc + row.codePaths.length, 0).toString(),
+    },
+  ];
+
+  return renderLayout({
+    title: options.title ?? 'SOIPack İzlenebilirlik Matrisi',
+    manifestId: options.manifestId ?? 'N/A',
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    version: options.version ?? packageInfo.version,
+    summaryMetrics,
+    content: traceTemplate.render({ rows }),
+    subtitle: 'Gereksinim → Test → Kod eşleşmelerinin kurumsal görünümü',
+  });
+};
+
+export const renderGaps = (
+  snapshot: ComplianceSnapshot,
+  options: GapReportOptions = {},
+): string => {
+  const objectiveLookup = new Map(options.objectivesMetadata?.map((objective) => [objective.id, objective]));
+
+  const categories = (Object.keys(snapshot.gaps) as GapCategoryKey[]).map((key) => {
+    const items: GapReportRow[] = snapshot.gaps[key].map((gap) => {
+      const metadata = objectiveLookup.get(gap.objectiveId);
+      return {
+        objectiveId: gap.objectiveId,
+        description: metadata?.description,
+        area: metadata?.area,
+        missingArtifacts: gap.missingArtifacts.map(formatArtifact),
+      };
+    });
+
+    return {
+      key,
+      label: gapLabels[key],
+      items,
+    };
+  });
+
+  const summaryMetrics: LayoutSummaryMetric[] = (Object.keys(snapshot.gaps) as GapCategoryKey[]).map((key) => ({
+    label: gapSummaryLabels[key],
+    value: snapshot.gaps[key].length.toString(),
+  }));
+
+  return renderLayout({
+    title: options.title ?? 'SOIPack Uyumluluk Boşlukları',
+    manifestId: options.manifestId ?? 'N/A',
+    generatedAt: options.generatedAt ?? snapshot.generatedAt,
+    version: options.version ?? packageInfo.version,
+    summaryMetrics,
+    content: gapsTemplate.render({ categories }),
+    subtitle: 'Kanıt eksikliği bulunan alanların özet görünümü',
+  });
+};
+
+const buildHeaderTemplate = (version: string, generatedAt: string): string => {
+  const safeVersion = escapeHtml(version);
+  const safeDate = escapeHtml(formatDate(generatedAt));
+  return `<div style="font-family:Arial,Helvetica,sans-serif;font-size:9px;color:#0f172a;width:100%;padding:0 24px;display:flex;justify-content:space-between;align-items:center;">` +
+    `<span>SOIPack Sürüm ${safeVersion}</span><span>${safeDate}</span></div>`;
+};
+
+const buildFooterTemplate = (manifestId: string): string => {
+  const safeManifest = escapeHtml(manifestId);
+  return `<div style="font-family:Arial,Helvetica,sans-serif;font-size:9px;color:#475569;width:100%;padding:0 24px;display:flex;justify-content:space-between;align-items:center;">` +
+    `<span>Kanıt Manifest ID: ${safeManifest}</span><span>Sayfa <span class="pageNumber"></span> / <span class="totalPages"></span></span></div>`;
+};
+
+export const printToPDF = async (
+  html: string,
+  options: PrintToPdfOptions = {},
+): Promise<Buffer> => {
+  const playwright = options.playwright ?? (await import('playwright'));
+  let browser: Browser | undefined;
+  let page: Page | undefined;
+
+  try {
+    browser = await playwright.chromium.launch();
+    page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      displayHeaderFooter: true,
+      headerTemplate: buildHeaderTemplate(options.version ?? packageInfo.version, options.generatedAt ?? new Date().toISOString()),
+      footerTemplate: buildFooterTemplate(options.manifestId ?? 'N/A'),
+      margin: {
+        top: options.margin?.top ?? '60px',
+        bottom: options.margin?.bottom ?? '60px',
+        left: options.margin?.left ?? '20mm',
+        right: options.margin?.right ?? '20mm',
+      },
+    });
+
+    return pdf;
+  } finally {
+    if (page) {
+      await page.close().catch(() => undefined);
+    }
+
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+  }
+};
+
+// Legacy exports kept for backward compatibility within the monorepo.
 export interface HtmlReportOptions {
   title?: string;
 }
@@ -10,8 +835,13 @@ export interface PdfPage {
   pdf: (options: { printBackground: boolean }) => Promise<Buffer>;
 }
 
+interface LegacyTraceMatrixRow {
+  requirementId: string;
+  testCaseIds: string[];
+}
+
 export const renderHtmlReport = (
-  matrix: TraceMatrix[],
+  matrix: LegacyTraceMatrixRow[],
   requirements: Requirement[],
   testCases: TestCase[],
   options: HtmlReportOptions = {},
@@ -23,17 +853,18 @@ export const renderHtmlReport = (
   const rows = matrix
     .map((entry) => {
       const requirement = requirementLookup.get(entry.requirementId);
-      const tests = entry.testCaseIds.map((id) => testLookup.get(id)?.name ?? id).join(', ');
+      const tests = entry.testCaseIds.map((id: string) => testLookup.get(id)?.name ?? id).join(', ');
 
       return `<tr><td>${requirement?.title ?? entry.requirementId}</td><td>${tests}</td></tr>`;
     })
     .join('');
 
-  return `<!DOCTYPE html><html><head><meta charset="utf-8" /><title>${title}</title></head><body><h1>${title}</h1><table><thead><tr><th>Requirement</th><th>Test Cases</th></tr></thead><tbody>${rows}</tbody></table></body></html>`;
+  return `<!DOCTYPE html><html><head><meta charset="utf-8" /><title>${title}</title></head><body><h1>${title}</h1><table><thead>` +
+    `<tr><th>Requirement</th><th>Test Cases</th></tr></thead><tbody>${rows}</tbody></table></body></html>`;
 };
 
 export const renderJsonReport = (
-  matrix: TraceMatrix[],
+  matrix: LegacyTraceMatrixRow[],
   requirements: Requirement[],
   testCases: TestCase[],
 ): Record<string, unknown> => ({
@@ -45,8 +876,8 @@ export const renderJsonReport = (
       status: 'draft',
       tags: [],
     },
-    tests: entry.testCaseIds.map(
-      (id) => testCases.find((test) => test.id === id) ?? { id, name: id },
+    tests: entry.testCaseIds.map((id: string) =>
+      testCases.find((test) => test.id === id) ?? { id, name: id },
     ),
   })),
 });

--- a/packages/report/tsconfig.build.json
+++ b/packages/report/tsconfig.build.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "composite": true
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../engine" },
+    { "path": "../adapters" }
+  ]
 }


### PR DESCRIPTION
## Summary
- implement Nunjucks-based compliance, trace, and gap report renderers plus Playwright PDF output
- add fixtures with golden hash tests to keep HTML output stable
- provide a demo script that writes HTML/JSON/PDF reports and update dependencies accordingly

## Testing
- npm test -w packages/report
- npm run demo -w packages/report

------
https://chatgpt.com/codex/tasks/task_b_68ce74b62ce0832885bb3637bda7abca