### PR TITLE
feat(cli): add end-to-end pipeline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,65 @@ npm install
 | `npm run format`       | Prettier ile biçimlendirme uygular.        |
 | `npm run format:check` | Prettier biçimlendirmesini kontrol eder.   |
 
+## 5 dakikada demo
+
+CLI paketini derleyip minimal örnek verilerle uçtan uca bir paket oluşturmak için aşağıdaki adımları izleyin. Tüm komutlar depo kök dizininden çalıştırılmalıdır.
+
+1. CLI derlemesini hazırlayın:
+
+   ```bash
+   npm run --workspace @soipack/cli build
+   ```
+
+2. Örnek artefaktları çalışma alanına aktarın:
+
+   ```bash
+   node packages/cli/dist/index.js import \
+     --jira examples/minimal/issues.csv \
+     --reqif examples/minimal/spec.reqif \
+     --junit examples/minimal/results.xml \
+     --lcov examples/minimal/lcov.info \
+     --cobertura examples/minimal/coverage.xml \
+     --git . \
+     --project-name "SOIPack Demo Avionics" \
+     --project-version "1.0.0" \
+     --level C \
+     --objectives data/objectives/do178c_objectives.min.json \
+     -o .soipack/work
+   ```
+
+3. Uyum analizini üretin:
+
+   ```bash
+   node packages/cli/dist/index.js analyze \
+     -i .soipack/work \
+     -o .soipack/out \
+     --level C \
+     --objectives data/objectives/do178c_objectives.min.json \
+     --project-name "SOIPack Demo Avionics" \
+     --project-version "1.0.0"
+   ```
+
+4. Raporları oluşturun:
+
+   ```bash
+   node packages/cli/dist/index.js report -i .soipack/out -o dist/reports
+   ```
+
+5. Dağıtım paketini hazırlayın:
+
+   ```bash
+   node packages/cli/dist/index.js pack -i dist -o release --name soipack-demo.zip
+   ```
+
+Tek komutla tüm adımların çalıştığı pipeline için örnek yapılandırmayı kullanabilirsiniz:
+
+```bash
+node packages/cli/dist/index.js run --config examples/minimal/soipack.config.yaml
+```
+
+Bu adımlar `examples/minimal` altındaki örnek verilerle birlikte çalışır. Aynı dizindeki `demo.sh` betiği, CLI derlemesini kontrol ederek pipeline komutunu otomatik olarak çalıştırır.
+
 ### Ed25519 Anahtar Üretimi
 
 Paket manifestlerini imzalamak için bir Ed25519 anahtar çifti oluşturun:

--- a/examples/minimal/coverage.xml
+++ b/examples/minimal/coverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage>
+  <packages>
+    <package name="demo">
+      <classes>
+        <class name="Demo" filename="src/main.c">
+          <methods>
+            <method name="main" hits="1" />
+          </methods>
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" branch="false" />
+            <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/examples/minimal/demo.sh
+++ b/examples/minimal/demo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="$ROOT_DIR/examples/minimal/soipack.config.yaml"
+CLI_DIST="$ROOT_DIR/packages/cli/dist/index.js"
+
+if [ ! -f "$CLI_DIST" ]; then
+  echo "Building SOIPack CLI..."
+  npm run --workspace @soipack/cli build >/dev/null
+fi
+
+echo "Running pipeline with $CONFIG"
+node "$CLI_DIST" run --config "$CONFIG"

--- a/examples/minimal/issues.csv
+++ b/examples/minimal/issues.csv
@@ -1,0 +1,3 @@
+"Issue key","Summary","Status","Priority"
+"REQ-1","Flight control computer shall start within 5s","Done","High"
+"REQ-2","Display health indication on primary screen","In Progress","Medium"

--- a/examples/minimal/lcov.info
+++ b/examples/minimal/lcov.info
@@ -1,0 +1,8 @@
+TN:
+SF:src/main.c
+DA:1,1
+DA:2,1
+DA:3,0
+LF:3
+LH:2
+end_of_record

--- a/examples/minimal/results.xml
+++ b/examples/minimal/results.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="DemoSuite" tests="3" failures="0" skipped="1">
+  <testcase classname="DemoSuite" name="verifies requirement 1" time="1.2">
+    <properties>
+      <property name="requirements" value="REQ-1" />
+    </properties>
+  </testcase>
+  <testcase classname="DemoSuite" name="verifies requirements 2 and 3" time="1.5">
+    <properties>
+      <property name="requirements" value="REQ-2 REQ-3" />
+    </properties>
+  </testcase>
+  <testcase classname="DemoSuite" name="pending failure case" time="0.5">
+    <skipped />
+  </testcase>
+</testsuite>

--- a/examples/minimal/soipack.config.yaml
+++ b/examples/minimal/soipack.config.yaml
@@ -1,0 +1,21 @@
+project:
+  name: "SOIPack Demo Avionics"
+  version: "1.0.0"
+level: "C"
+objectives:
+  file: "../../data/objectives/do178c_objectives.min.json"
+inputs:
+  jira: "issues.csv"
+  reqif: "spec.reqif"
+  junit: "results.xml"
+  lcov: "lcov.info"
+  cobertura: "coverage.xml"
+  git: "../.."
+output:
+  work: ".soipack/work"
+  analysis: ".soipack/out"
+  reports: "dist/reports"
+  release: "release"
+pack:
+  name: "soipack-demo.zip"
+  input: "dist"

--- a/examples/minimal/spec.reqif
+++ b/examples/minimal/spec.reqif
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF>
+  <CORE-CONTENT>
+    <SPEC-OBJECTS>
+      <SPEC-OBJECT IDENTIFIER="REQ-3">
+        <VALUES>
+          <ATTRIBUTE-VALUE-XHTML>
+            <THE-VALUE>Log flight faults for post-flight review.</THE-VALUE>
+          </ATTRIBUTE-VALUE-XHTML>
+        </VALUES>
+      </SPEC-OBJECT>
+    </SPEC-OBJECTS>
+  </CORE-CONTENT>
+</REQ-IF>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1937,7 +1937,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1947,7 +1946,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2609,7 +2607,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2642,7 +2639,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2655,7 +2651,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3071,7 +3066,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -3243,7 +3237,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4083,7 +4076,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4736,7 +4728,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6782,7 +6773,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7339,7 +7329,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7413,7 +7402,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8172,7 +8160,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8211,7 +8198,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8224,11 +8210,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -8247,7 +8244,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8311,10 +8307,17 @@
         "@soipack/adapters": "0.1.0",
         "@soipack/core": "0.1.0",
         "@soipack/engine": "0.1.0",
-        "@soipack/report": "0.1.0"
+        "@soipack/packager": "0.1.0",
+        "@soipack/report": "0.1.0",
+        "yaml": "^2.4.2",
+        "yargs": "^17.7.2",
+        "yazl": "^2.5.1"
       },
       "bin": {
         "soipack": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/yazl": "^2.4.4"
       }
     },
     "packages/core": {

--- a/packages/adapters/tsconfig.build.json
+++ b/packages/adapters/tsconfig.build.json
@@ -3,5 +3,8 @@
   "compilerOptions": {
     "composite": true
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts"],
+  "references": [
+    { "path": "../core/tsconfig.build.json" }
+  ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,10 +12,17 @@
     "@soipack/adapters": "0.1.0",
     "@soipack/core": "0.1.0",
     "@soipack/engine": "0.1.0",
-    "@soipack/report": "0.1.0"
+    "@soipack/packager": "0.1.0",
+    "@soipack/report": "0.1.0",
+    "yaml": "^2.4.2",
+    "yargs": "^17.7.2",
+    "yazl": "^2.5.1"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "jest --config ./jest.config.cjs"
+  },
+  "devDependencies": {
+    "@types/yazl": "^2.4.4"
   }
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,38 +1,77 @@
-import { AdapterMetadata } from '@soipack/adapters';
+import os from 'os';
+import path from 'path';
+import { promises as fs } from 'fs';
 
-import { runCli } from './index';
+import { exitCodes, runAnalyze, runImport, runPack, runReport } from './index';
 
-describe('@soipack/cli', () => {
-  const adapters: AdapterMetadata[] = [
-    { name: 'Jira CSV', supportedArtifacts: ['CSV'] },
-    { name: 'JUnit XML', supportedArtifacts: ['XML'] },
-  ];
+describe('@soipack/cli pipeline', () => {
+  const fixturesDir = path.resolve(__dirname, '../../../examples/minimal');
+  const objectivesPath = path.resolve(__dirname, '../../../data/objectives/do178c_objectives.min.json');
+  let tempRoot: string;
 
-  it('lists adapters', async () => {
-    const output = await runCli('list-adapters', { adapters, requirements: [], testCases: [] });
-    expect(output).toContain('Jira CSV: csv');
-    expect(output).toContain('JUnit XML: xml');
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'soipack-cli-'));
   });
 
-  it('generates HTML and JSON sections', async () => {
-    const output = await runCli('generate-report', {
-      adapters,
-      requirements: [
-        {
-          id: 'REQ-1',
-          title: 'Provide authentication',
-        },
-      ],
-      testCases: [
-        {
-          id: 'TC-1',
-          name: 'should authenticate',
-          requirementId: 'REQ-1',
-        },
-      ],
+  afterAll(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('runs the minimal demo end-to-end', async () => {
+    const workDir = path.join(tempRoot, 'work');
+    const analysisDir = path.join(tempRoot, 'analysis');
+    const distDir = path.join(tempRoot, 'dist');
+    const reportsDir = path.join(distDir, 'reports');
+    const releaseDir = path.join(tempRoot, 'release');
+
+    const importResult = await runImport({
+      output: workDir,
+      jira: path.join(fixturesDir, 'issues.csv'),
+      reqif: path.join(fixturesDir, 'spec.reqif'),
+      junit: path.join(fixturesDir, 'results.xml'),
+      lcov: path.join(fixturesDir, 'lcov.info'),
+      cobertura: path.join(fixturesDir, 'coverage.xml'),
+      git: path.resolve(fixturesDir, '../..'),
+      level: 'C',
+      objectives: objectivesPath,
+      projectName: 'Demo Avionics',
+      projectVersion: '1.0.0',
     });
 
-    expect(output).toContain('<!DOCTYPE html>');
-    expect(output).toContain('"requirements"');
+    const workspaceStats = await fs.stat(path.join(workDir, 'workspace.json'));
+    expect(workspaceStats.isFile()).toBe(true);
+    expect(importResult.workspace.requirements.length).toBeGreaterThan(0);
+
+    const analysisResult = await runAnalyze({
+      input: workDir,
+      output: analysisDir,
+      level: 'C',
+      objectives: objectivesPath,
+      projectName: 'Demo Avionics',
+      projectVersion: '1.0.0',
+    });
+
+    expect([exitCodes.success, exitCodes.missingEvidence]).toContain(analysisResult.exitCode);
+
+    const reportResult = await runReport({
+      input: analysisDir,
+      output: reportsDir,
+    });
+
+    const complianceHtmlStats = await fs.stat(reportResult.complianceHtml);
+    expect(complianceHtmlStats.isFile()).toBe(true);
+
+    const packResult = await runPack({
+      input: distDir,
+      output: releaseDir,
+      packageName: 'demo.zip',
+    });
+
+    const archiveStats = await fs.stat(packResult.archivePath);
+    expect(archiveStats.isFile()).toBe(true);
+    expect(packResult.manifestId).toHaveLength(12);
+
+    const manifestStats = await fs.stat(packResult.manifestPath);
+    expect(manifestStats.isFile()).toBe(true);
   });
 });

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "composite": true
   },
+  "references": [
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../adapters/tsconfig.build.json" },
+    { "path": "../engine/tsconfig.build.json" },
+    { "path": "../report/tsconfig.build.json" },
+    { "path": "../packager/tsconfig.build.json" }
+  ],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/engine/tsconfig.build.json
+++ b/packages/engine/tsconfig.build.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "composite": true
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts"],
+  "references": [
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../adapters/tsconfig.build.json" }
+  ]
 }

--- a/packages/packager/tsconfig.build.json
+++ b/packages/packager/tsconfig.build.json
@@ -5,6 +5,6 @@
   },
   "exclude": ["src/**/*.test.ts"],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.build.json" }
   ]
 }

--- a/packages/report/tsconfig.build.json
+++ b/packages/report/tsconfig.build.json
@@ -5,8 +5,8 @@
   },
   "exclude": ["src/**/*.test.ts"],
   "references": [
-    { "path": "../core" },
-    { "path": "../engine" },
-    { "path": "../adapters" }
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../engine/tsconfig.build.json" },
+    { "path": "../adapters/tsconfig.build.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the CLI with dedicated import, analyze, report, pack and run commands that orchestrate adapters, engine and packager logic
- add a minimal demo dataset with pipeline config and helper script to exercise the workflow
- document five-minute demo steps in the README and wire TypeScript project references for dependent packages

## Testing
- npm run --workspace @soipack/cli test
- npm run --workspace @soipack/cli build

------
https://chatgpt.com/codex/tasks/task_b_68ce7c4fab0c8328919d7e0455f8857b