### PR TITLE
Add Docker deployment stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Node dependencies
+node_modules
+**/node_modules
+
+# Build artifacts
+**/dist
+
+# Local data and caches
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+
+# Git and editor metadata
+.git
+.gitignore
+.idea
+.vscode
+.DS_Store
+
+# Runtime data
+coverage
+.tmp

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-SOIPACK_API_TOKEN=change-me
-SOIPACK_STORAGE_DIR=.soipack/server
+# SOIPack API authentication token
+SOIPACK_API_TOKEN=degiştir-beni
+
+# Host port published by docker compose (optional)
 PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.5
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+
+# Install dependencies and prepare the workspace
+COPY package.json package-lock.json tsconfig.json tsconfig.base.json tsconfig.build.json ./
+COPY packages ./packages
+COPY docs ./docs
+COPY scripts ./scripts
+COPY data ./data
+COPY examples ./examples
+
+RUN npm ci \
+  && npm run build \
+  && npm cache clean --force
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy the compiled application and production dependencies
+COPY --from=builder /app /app
+
+# Install Playwright browsers and required system dependencies
+RUN npx playwright install --with-deps chromium \
+  && rm -rf /var/lib/apt/lists/*
+
+# Final runtime configuration
+RUN mkdir -p /app/data \
+  && chown -R node:node /app \
+  && npm cache clean --force
+
+VOLUME ["/app/data"]
+
+ENV SOIPACK_STORAGE_DIR=/app/data \
+    PORT=3000
+
+EXPOSE 3000
+
+USER node
+
+ENTRYPOINT ["node", "node_modules/.bin/tsx", "packages/server/src/start.ts"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: "3.9"
+
+services:
+  server:
+    image: soipack/server:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      SOIPACK_API_TOKEN: ${SOIPACK_API_TOKEN:?SOIPACK_API_TOKEN tanımlanmalıdır}
+      SOIPACK_STORAGE_DIR: /app/data
+      PORT: ${PORT:-3000}
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://localhost:3000/health',{headers:{Authorization:'Bearer '+process.env.SOIPACK_API_TOKEN}}).then(res=>{if(!res.ok)process.exit(1);}).catch(()=>process.exit(1));"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,124 @@
+# Air-Gapped SOIPack Sunucu Dağıtımı
+
+Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST API sunucusunu Docker ile çalıştırmak için izlenmesi gereken adımları açıklar. Süreç iki aşamadan oluşur: internet erişimi olan hazırlık makinesi ve hedef air-gapped ortam.
+
+## 1. Hazırlık Makinesinde İmajı Oluşturma
+
+1. Gerekli araçları yükleyin:
+   - Docker 24+
+   - Docker Compose plugin
+   - Git
+2. Kaynak kodunu klonlayın ve dizine girin:
+   ```bash
+   git clone https://github.com/<kurumunuz>/SOIPack.git
+   cd SOIPack
+   ```
+3. Üretim derlemesini hazırlayın. Bu adım, çok-aşamalı Docker imajında da çalıştırıldığı için Playwright tarayıcıları dâhil tüm bağımlılıkları indirir:
+   ```bash
+   npm ci
+   npm run build
+   ```
+4. Konteyner imajını oluşturun:
+   ```bash
+   docker build -t soipack/server:latest .
+   ```
+5. İmajı air-gapped ortama taşıyabilmek için dışa aktarın:
+   ```bash
+   docker save soipack/server:latest | gzip > soipack-server.tar.gz
+   ```
+6. Aşağıdaki dosyaları hedef ortama kopyalayın:
+   - `soipack-server.tar.gz`
+   - `docker-compose.yaml`
+   - `.env.example` yerine oluşturacağınız `.env` dosyası için şablon (aşağıya bakın)
+   - `data/` dizini (hedefte kalıcı depolama için aynı yolu kullanacağız)
+   - Örnek veri setleri (isteğe bağlı olarak `examples/minimal/`)
+
+> **Not:** Docker imajı Playwright'ın `chromium` motoru ve ilgili sistem paketleriyle birlikte gelir. Air-gapped ortamda ek bağımlılık indirmenize gerek yoktur.
+
+## 2. Air-Gapped Ortamda Kurulum
+
+1. Dosyaları hedef makinede uygun bir klasöre çıkarın ve `data/` dizininin bulunduğundan emin olun:
+   ```bash
+   tar -xzf soipack-server.tar.gz
+   ls data/objectives/do178c_objectives.min.json
+   ```
+2. Docker imajını içe aktarın:
+   ```bash
+   docker load < soipack-server.tar.gz
+   ```
+3. Sunucunun ihtiyaç duyduğu ortam değişkenlerini tanımlayın. `SOIPACK_API_TOKEN` zorunludur. Aynı klasörde bir `.env` dosyası oluşturun:
+   ```bash
+   cat <<'ENV' > .env
+   SOIPACK_API_TOKEN=degiştir-beni
+   PORT=3000
+   ENV
+   ```
+4. Kalıcı depolama için `data/` dizinini kullanarak servisi başlatın:
+   ```bash
+   docker compose up -d
+   ```
+5. Sağlık kontrolünü doğrulayın:
+   ```bash
+   docker compose ps
+   curl -H "Authorization: Bearer $SOIPACK_API_TOKEN" http://localhost:3000/health
+   ```
+
+Sunucu sağlıklı dönerse çıktı `{"status":"ok"}` olacaktır. Tüm iş çıktıları (yüklemeler, analizler, raporlar ve paketler) `data/` dizininde saklanır ve konteyner yeniden başlatıldığında korunur.
+
+## 3. Örnek Pipeline Çağrısı
+
+Aşağıdaki örnek, `examples/minimal/` dizinindeki demo verilerini kullanarak uçtan uca PDF raporu oluşturur. Komutları çalıştırmadan önce `TOKEN` değişkenini ayarlayın:
+
+```bash
+TOKEN=$SOIPACK_API_TOKEN
+BASE_URL=http://localhost:3000
+```
+
+1. Gereken demo dosyalarını içeren bir import isteği gönderin:
+   ```bash
+   curl -X POST "$BASE_URL/v1/import" \
+     -H "Authorization: Bearer $TOKEN" \
+     -F "projectName=SOIPack Demo" \
+     -F "projectVersion=1.0" \
+     -F "level=C" \
+     -F "reqif=@examples/minimal/spec.reqif" \
+     -F "junit=@examples/minimal/results.xml" \
+     -F "lcov=@examples/minimal/lcov.info" \
+     -F "cobertura=@examples/minimal/coverage.xml" \
+     -F "objectives=@data/objectives/do178c_objectives.min.json"
+   ```
+   Dönen JSON içindeki `id` alanını `IMPORT_ID` olarak saklayın.
+
+2. Analiz isteği gönderin:
+   ```bash
+   curl -X POST "$BASE_URL/v1/analyze" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"importId\":\"$IMPORT_ID\"}"
+   ```
+   Yanıttaki `id` değerini `ANALYSIS_ID` olarak kaydedin.
+
+3. Rapor üretin (PDF ve HTML çıktıları bu adımda oluşur):
+   ```bash
+   curl -X POST "$BASE_URL/v1/report" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"analysisId\":\"$ANALYSIS_ID\"}"
+   ```
+   Yanıttaki `outputs.directory` alanı, `data/` altında oluşturulan rapor klasörünü gösterir. Örneğin `data/reports/<rapor-id>/compliance_matrix.pdf` dosyasını açarak PDF üretimini doğrulayabilirsiniz.
+
+4. (İsteğe bağlı) Raporu paketleyin:
+   ```bash
+   curl -X POST "$BASE_URL/v1/pack" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"reportId\":\"<rapor-id>\"}"
+   ```
+
+## 4. Güncelleme ve Bakım
+
+- Yeni bir sürüm yayınlandığında, hazırlık makinesinde `docker build` ve `docker save` adımlarını tekrar ederek yeni imajı içe aktarın.
+- Kalıcı `data/` klasörünü düzenli olarak yedekleyin.
+- `docker compose logs -f server` komutu ile hata ayıklama günlüklerini takip edebilirsiniz.
+
+Bu adımlar tamamlandığında air-gapped ortamda `docker compose up -d` komutuyla SOIPack API'si PDF/rapor üretecek şekilde hazır olacaktır.

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "composite": true
   },
+  "references": [
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../adapters/tsconfig.build.json" },
+    { "path": "../engine/tsconfig.build.json" },
+    { "path": "../report/tsconfig.build.json" },
+    { "path": "../cli/tsconfig.build.json" }
+  ],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile based on Node 20 that installs Playwright dependencies and runs the server via tsx
- introduce a docker compose stack with a persistent data volume, health check, and sample environment configuration
- document the air-gapped deployment workflow, including sample pipeline calls for generating reports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce930574a483289a5329a29ec4c28d