### PR TITLE
Add SOIPack documentation bundle

### DIFF
--- a/docs/soipack_acceptance_checklist.md
+++ b/docs/soipack_acceptance_checklist.md
@@ -1,0 +1,26 @@
+# SOIPack Müşteri Kabul Kontrol Listesi
+
+Bu kontrol listesi, SOIPack demo paketinin müşteri veya denetçi tesliminden önce doğrulanması gereken adımları tanımlar. Her madde tamamlandığında tarih ve sorumlu kişi kaydedilmelidir.
+
+## Hazırlık
+- [ ] Depo kökünde `npm install` komutu çalıştırıldı ve bağımlılıklar başarıyla yüklendi.【F:README.md†L24-L33】
+- [ ] `scripts/make-demo.sh` betiği hava boşluklu veya izole ortamda çalıştırıldı; terminal çıktısı arşivlendi.【F:docs/demo_script.md†L10-L17】
+- [ ] Lisans dosyası (`LICENSE`) ve müşteri lisans anahtarları doğrulandı; CLI tarafından hata üretilmedi.【F:docs/demo_script.md†L10-L17】【F:packages/cli/src/index.ts†L40-L115】
+
+## Rapor Doğrulaması
+- [ ] `dist/reports/compliance_matrix.html` açılarak tüm DO-178C hedefleri gözden geçirildi; eksik kanıt işaretleri not edildi.【F:docs/demo_script.md†L18-L22】
+- [ ] `dist/reports/gaps.html` kontrol edilerek kırmızı satırlar için açıklama/ticket referansları eklendi.【F:docs/demo_script.md†L22-L23】
+- [ ] `dist/reports/trace_matrix.html` üzerinden rastgele gereksinim → test → kod zinciri örnekleri takip edildi.【F:docs/demo_script.md†L23-L24】
+- [ ] `dist/reports/compliance_matrix.pdf` müşteri arşivi için saklandı ve hash değeri kabul raporuna eklendi.【F:docs/demo_script.md†L18-L25】
+
+## Paket ve Güvenlik
+- [ ] `release/manifest.json` ve `manifest.sig` dosyaları saklandı; hash doğrulaması bağımsız olarak tekrarlandı.【F:docs/demo_script.md†L26-L31】
+- [ ] `release/soi-pack-*.zip` arşivi açılarak raporların ve manifestlerin paket içinde bulunduğu teyit edildi.【F:docs/demo_script.md†L26-L31】
+- [ ] Anahtar yönetimi prosedürleri `docs/soipack_security.md` ile uyumlu şekilde belgelenmiş ve müşteriye iletilmiştir.【F:docs/soipack_security.md†L1-L64】
+
+## Teslimat
+- [ ] Raporlar ve paket, müşteri tarafından belirtilen kanallar üzerinden paylaşıldı (örn. güvenli dosya transferi, fiziksel medya).
+- [ ] `docs/soipack_user_guide.md` ve `docs/soipack_tool_assessment_stub_DO330.md` dokümanları teslimat paketine eklendi.
+- [ ] Kabul toplantısı sırasında raporların canlı gösterimi planlandı ve `docs/demo_script.md` akışına göre prova yapıldı.【F:docs/demo_script.md†L1-L31】
+
+Bu liste tamamlandığında müşteri kabul onayı alınabilir ve SOIPack artefaktları resmi denetim arşivine aktarılabilir.

--- a/docs/soipack_security.md
+++ b/docs/soipack_security.md
@@ -1,0 +1,26 @@
+# SOIPack Güvenlik ve Bütünlük Notları
+
+SOIPack, gereksinim izlenebilirliği sonuçlarını paketlerken manifest imzası ve kontrollü anahtar yönetimiyle bütünlüğü korumayı hedefler. Bu doküman, demo ortamındaki güvenlik varsayımlarını üretim senaryolarına taşımak için izlenmesi gereken yöntemleri özetler.
+
+## Anahtar Yönetimi
+
+- **Ed25519 anahtar çifti**: Paket imzaları Ed25519 algoritmasıyla üretilir. Demo kurulumu OpenSSL ile aşağıdaki komutla uyumlu anahtar üretimini örnekler; aynı akış üretim anahtarının hazırlanması için de geçerlidir.【F:README.md†L75-L88】
+- **Anahtar depolama**: Özel anahtarlar (örn. `ed25519_private.pem`) hava boşluklu (air-gap) bir anahtar kasasında veya donanımsal güvenlik modülünde saklanmalıdır. SOIPack pipeline'ı anahtarı diskten okur, bu nedenle çalışma zamanında sadece imzalama adımının gerçekleştiği izole ortamlarda kullanılmalıdır.
+- **Anahtar rotasyonu**: `manifest.json` içindeki `signer` alanı (üretim senaryosunda özelleştirilmelidir) yeni anahtara geçişleri kayıt altına almak için kullanılabilir. Yeni anahtara geçildiğinde önceki manifestlerin doğrulanabilirliği sağlanmalı ve kamu anahtarları tüketicilerle güvenli kanallardan paylaşılmalıdır.
+
+## İmza Akışı
+
+1. **Rapor üretimi**: `node packages/cli/dist/index.js report` komutu `dist/reports/` altında HTML ve PDF raporları oluşturur; bunlar `compliance_matrix.html`, `trace_matrix.html` ve `compliance_matrix.pdf` dosyalarını içerir.【F:docs/demo_script.md†L18-L25】
+2. **Manifest oluşturma**: `pack` komutu `dist/` dizinini tarar, içerik karmalarını çıkarır ve sonuçları `release/manifest.json` dosyasında toplar.【F:packages/cli/src/index.ts†L556-L654】
+3. **İmza üretimi**: Aynı adımda manifestin SHA-256 özeti `release/manifest.sig` dosyasına yazılır; üretim ortamında bu değer Ed25519 özel anahtarıyla imzalanmış base64 çıktıyla değiştirilmelidir.【F:packages/cli/src/index.ts†L612-L654】
+4. **Arşivleme**: Manifest ve imza `release/soi-pack-*.zip` paketine dahil edilir. Demo senaryosunda `scripts/make-demo.sh` bu arşivi uçtan uca üretir ve terminalde yolları raporlar.【F:docs/demo_script.md†L26-L31】
+5. **Doğrulama**: Paket tüketicileri manifestin karmasını yeniden hesaplayıp `manifest.sig` ile karşılaştırmalı; hava boşluklu ortamlarda doğrulama ofline yapılır.
+
+## Air-Gap ve İzolasyon
+
+- **Hazırlık aşaması**: Veri içe aktarma (`import`) ve analiz (`analyze`) adımları çevrimdışı çalışabilir. Air-gap senaryosunda örnek veriler USB/taşınabilir disk üzerinden izole ortama getirilmeli ve `scripts/make-demo.sh` veya YAML pipeline konfigürasyonu air-gap içinde çalıştırılmalıdır.【F:docs/demo_script.md†L10-L31】【F:README.md†L36-L73】
+- **Lisans doğrulaması**: `verifyLicenseFile` adımı lisans dosyasını okumak için yerel dosya erişimi kullanır; dış ağ çağrısı yapılmaz, bu da air-gap uyumluluğunu destekler.【F:packages/cli/src/index.ts†L40-L115】
+- **Çıkış materyalleri**: Üretilen `release/soi-pack-*.zip` paketi hava boşluklu ağdan ayrılmadan önce bir offline virüs taramasından geçirilmeli, ardından fiziksel medyayla müşteri ağına taşınmalıdır.
+- **İz kayıtları**: `manifest.json` içindeki tarih damgası (`generatedAt`) sabitlenmiş demo zaman damgasıyla (`SOIPACK_DEMO_TIMESTAMP`) veya gerçek zamanlı saatle üretilir. Air-gap ortamında saat senkronizasyonu güvenilir NTP yerine kontrollü manuel prosedürlerle yapılmalıdır.【F:packages/cli/src/index.ts†L48-L115】
+
+Bu prosedürler, demo çıktılarındaki raporların ve manifestlerin denetlenebilirliğini korurken, üretim süreçlerinde uyarlanabilir güvenlik kontrolleri sağlar.

--- a/docs/soipack_tool_assessment_stub_DO330.md
+++ b/docs/soipack_tool_assessment_stub_DO330.md
@@ -1,0 +1,54 @@
+# SOIPack Tool Assessment Stub (DO-330)
+
+Bu belge, SOIPack CLI pipeline'ının DO-330 kapsamında **kredi vermeyen destek aracı** (development support tool, no certification credit) olarak konumlandırılması için başlangıç iskeletini sunar. Amaç; müşteri denetimlerinde sunulacak izlenebilirlik çıktılarının nasıl üretildiğini ve hangi kontrollerle doğrulandığını şeffaf şekilde göstermek, ancak aracın sonuçlarına doğrudan sertifikasyon kredisi tahsis etmemektir.
+
+## 1. Araç Tanımı
+- **Adı**: SOIPack CLI Pipeline
+- **Sürüm**: Depo etiketi veya `SOIPACK_COMMIT` ortam değişkeni üzerinden izlenir.【F:packages/cli/src/version.ts†L1-L18】
+- **Fonksiyonel Kapsam**: Gereksinim, test ve kaynak kodu bağdaştırıcılardan içe aktarır; izlenebilirlik grafı oluşturur; `compliance_matrix.html`, `trace_matrix.html`, `gaps.html` ve `compliance_matrix.pdf` raporlarını üretir; manifest imzalı `release/soi-pack-*.zip` paketini oluşturur.【F:docs/demo_script.md†L18-L31】
+
+## 2. Operasyonel Kullanım Senaryosu
+- Araç, kalite ekibinin izlenebilirlik delillerini toplaması için kullanılır.
+- Çalıştırma genellikle `scripts/make-demo.sh` veya eşdeğer YAML konfigürasyonuyla tetiklenen tek komutluk pipeline üzerinden yapılır.【F:docs/demo_script.md†L10-L31】【F:README.md†L36-L73】
+- Sonuçlar müşteri incelemesi sırasında `dist/reports/` altındaki HTML/PDF dosyaları üzerinden sunulur ve paket manifesti denetçilerle paylaşılır.【F:docs/demo_script.md†L18-L31】
+
+## 3. DO-330 Sınıflandırması
+- **Araç Türü**: Development Support Tool (DO-330 §11.4).
+- **TQL Önerisi**: TQL-5 (kredi vermeyen destek aracı). Gerekçe:
+  - Araç, süreç çıktılarının derlenmesinde yardımcı olur; doğrudan ürün yazılımının doğrulanması veya onaylanması için tek kaynak olarak kullanılmaz.
+  - `gaps.html` raporu, eksik kanıtları işaretler ancak düzeltici işlemler ayrı mühendislik süreçleriyle yönetilir.【F:docs/demo_script.md†L22-L23】
+  - Paket manifesti (`manifest.json`/`manifest.sig`) doğrulaması, sonuçların manuel denetimini kolaylaştırır fakat sertifikasyon kredisi tanımlamaz.【F:docs/demo_script.md†L26-L31】
+
+## 4. Güvence Argümanı
+- **İzlenebilirlik doğrulaması**: `trace_matrix.html` gereksinim-test-kod bağlantılarını görselleştirir; doğrulama ekibi sonuçları manuel olarak çapraz kontrol eder.【F:docs/demo_script.md†L23-L24】
+- **Uyum değerlendirmesi**: `compliance_matrix.html` ve `compliance_matrix.pdf`, DO-178C hedeflerinin sağlanma durumunu özetler; test kanıtı eksikse `gaps.html` uyarı sağlar.【F:docs/demo_script.md†L18-L25】
+- **Tekrarlanabilirlik**: Pipeline komutları `README.md` içinde belgelenmiştir, böylece denetim sırasında aynı girişlerle tekrar çalıştırılabilir.【F:README.md†L36-L73】
+- **Bütünlük**: `release/manifest.json` ve `manifest.sig` hash kontrolü sağlar; müşteri tarafı doğrulama prosedürü ile tamamlanmalıdır.【F:docs/demo_script.md†L26-L31】
+
+## 5. Tool Qualification Plan (TQP) İskeleti
+Bu bölüm, DO-330'a uygun tam TQP'nin taslağı olarak kullanılmak üzere başlıkları listeler. Her alt başlık daha sonra detaylandırılmalıdır.
+
+1. **Giriş**
+   - Amaç
+   - Referans dokümanlar (`docs/architecture.md`, `docs/demo_script.md`, `docs/soipack_security.md`)
+2. **Araç Tanımı**
+   - Bileşenler (Adapters, Core, Engine, Report, CLI) ve veri akışı özeti.【F:docs/architecture.md†L1-L24】
+   - Komut satırı arayüzü ve konfigürasyon dosyaları.
+3. **TQL Belirleme**
+   - DO-330 akışına göre kredi vermeyen destek aracının gerekçesi.
+   - Kullanıcı rollerine göre sorumluluk matrisi.
+4. **Niteliklendirme Stratejisi**
+   - Manuel doğrulama prosedürleri (rapor incelemesi, manifest kontrolü).
+   - Otomasyon destekleri (CI pipeline çıktıları, `demo_script` akışı).
+5. **Test Planı**
+   - Senaryo 1: Örnek veri seti ile demo pipeline (beklenen `release/soi-pack-*.zip`).
+   - Senaryo 2: Eksik kanıt içeren veri seti → beklenen çıkış kodu `2` ve `gaps.html` uyarıları.【F:docs/demo_script.md†L22-L23】【F:packages/cli/src/index.ts†L116-L763】
+6. **Konfigürasyon Yönetimi**
+   - Versiyonlama (`SOIPACK_COMMIT`), paket hashleri ve manifest saklama politikası.
+   - Lisans dosyası kontrolü (`verifyLicenseFile`) ve anahtar yönetimi özetine referans.【F:packages/cli/src/index.ts†L40-L115】【F:docs/soipack_security.md†L1-L64】
+7. **Problem Raporlama ve Çözümü**
+   - Hata kodu matrisi (`docs/soipack_user_guide.md`) ve olay kayıt prosedürü.
+8. **Onay ve Dağıtım**
+   - Air-gap dağıtım adımları, müşteri kabul kriterleri (`docs/soipack_acceptance_checklist.md`).
+
+Bu iskelet, denetçilerle paylaşılacak nihai TQP dokümanının bölümlerini tanımlar ve demo çıktılarındaki artefaktlara referans vererek SOIPack'in izlenebilirlik sağlama rolünü açıklar.

--- a/docs/soipack_user_guide.md
+++ b/docs/soipack_user_guide.md
@@ -1,0 +1,89 @@
+# SOIPack Kullanıcı Rehberi
+
+SOIPack, gereksinim-test izlenebilirliği, uyumluluk raporlaması ve imzalı dağıtım paketleri oluşturmak üzere tasarlanmış bir komut satırı araç seti sunar. Bu rehber, depoyu klonladıktan sonra aracı devreye almak, örnek veriyle uçtan uca çalıştırmak ve tipik hata kodlarını anlamak için gerekli adımları özetler.
+
+## Kurulum
+
+1. **Önkoşullar**
+   - Node.js 18 veya üzeri.
+   - Git ile klonlanmış SOIPack deposu.
+   - Opsiyonel: Paket manifestlerini imzalamak için OpenSSL 3.
+2. **Bağımlılıkların yüklenmesi**
+   ```bash
+   npm install
+   ```
+   Bu komut, monorepodaki tüm paketler için bağımlılıkları indirir ve `packages/` altındaki çalışma alanlarını hazırlar.
+3. **CLI derlemesi (isteğe bağlı)**
+   ```bash
+   npm run --workspace @soipack/cli build
+   ```
+   Demo akışında `scripts/make-demo.sh` derlemeyi otomatik yapar; manuel kullanım için CLI'nın `packages/cli/dist/` altında hazır olduğundan emin olun.
+
+## Kullanım
+
+### Tek komutla demo
+`scripts/make-demo.sh`, örnek verileri izole çalışma alanına kopyalar, lisans doğrulaması yapar ve uçtan uca pipeline'ı tetikler. Komut tamamlandığında aşağıdaki artefaktlar oluşur:
+
+- `dist/reports/compliance_matrix.html` – hedef-kanıt eşleşmelerini gösteren uyum matrisi.【F:docs/demo_script.md†L18-L22】
+- `dist/reports/gaps.html` – eksik kanıtların kırmızı ile işaretlendiği boşluk raporu.【F:docs/demo_script.md†L22-L23】
+- `dist/reports/trace_matrix.html` – gereksinim → test → kod zincirini takip eden izlenebilirlik matrisi.【F:docs/demo_script.md†L23-L24】
+- `release/soi-pack-*.zip` – raporlar, manifest ve imzaları içeren paket arşivi.【F:docs/demo_script.md†L26-L31】
+- `release/manifest.json` ve `release/manifest.sig` – paket bütünlüğünü denetlemek için kullanılan imzalı manifest çifti.【F:docs/demo_script.md†L29-L31】
+
+### Pipeline'ı manuel çalıştırma
+Aşağıdaki adımlar aynı çıktıları üretir ve kendi veri kümelerinizi kullanırken özelleştirilebilir:
+
+1. **Örnek veriyi içe aktarın**
+   ```bash
+   node packages/cli/dist/index.js import \
+     --jira examples/minimal/issues.csv \
+     --reqif examples/minimal/spec.reqif \
+     --junit examples/minimal/results.xml \
+     --lcov examples/minimal/lcov.info \
+     --cobertura examples/minimal/coverage.xml \
+     --git . \
+     --project-name "SOIPack Demo Avionics" \
+     --project-version "1.0.0" \
+     --level C \
+     --objectives data/objectives/do178c_objectives.min.json \
+     -o .soipack/work
+   ```
+2. **Uyum analizini hesaplayın**
+   ```bash
+   node packages/cli/dist/index.js analyze \
+     -i .soipack/work \
+     -o .soipack/out \
+     --level C \
+     --objectives data/objectives/do178c_objectives.min.json \
+     --project-name "SOIPack Demo Avionics" \
+     --project-version "1.0.0"
+   ```
+3. **Raporları üretin**
+   ```bash
+   node packages/cli/dist/index.js report -i .soipack/out -o dist/reports
+   ```
+4. **Dağıtım paketini oluşturun**
+   ```bash
+   node packages/cli/dist/index.js pack -i dist -o release --name soipack-demo.zip
+   ```
+
+Pipeline'ın YAML sürümü için `node packages/cli/dist/index.js run --config examples/minimal/soipack.config.yaml` komutunu çalıştırabilirsiniz; bu komut demo betiğinin tetiklediği konfigürasyonla aynıdır.【F:README.md†L36-L73】
+
+### Raporları inceleme
+Raporlar `dist/reports/` altında toplanır. `compliance_matrix.html` ve `trace_matrix.html` tarayıcıda açılarak müşteriye canlı demo yapılabilir; `compliance_matrix.pdf` aynı dizinde yer alır ve denetim arşivi için hazırdır.【F:docs/demo_script.md†L18-L25】 Paket arşivi, HTML/PDF raporlarını ve manifest dosyalarını `release/soi-pack-*.zip` içinde taşır.【F:docs/demo_script.md†L26-L31】
+
+## Hata Kodları
+SOIPack CLI süreçleri başarı ve başarısızlık durumlarını aşağıdaki çıkış kodlarıyla bildirir:
+
+| Kod | Tanım | Tipik Senaryo |
+| --- | ----- | ------------- |
+| `0` | Başarılı tamamlandı | Tüm adımlar hatasız tamamlandı; raporlar `dist/reports/` altında oluştu. |
+| `2` | Eksik kanıt bulundu | `gaps.html` raporu kırmızı satırlar içerir ve pipeline kritik kanıt eksiklikleri nedeniyle uyarıyla sonlanır. Paket yine de oluşturulur ancak kabul sürecinde inceleme gerektirir. |
+| `3` | Genel hata | Lisans doğrulaması başarısız oldu, giriş dosyaları okunamadı veya analiz sırasında beklenmeyen bir istisna oluştu. Terminal log'unda hata açıklaması görünür; pipeline `release/soi-pack-*.zip` dosyasını üretmez. |
+
+CLI'nin belirli alt komutları (`import`, `analyze`, `report`, `pack`, `run`) exit kodlarını `process.exitCode` aracılığıyla raporlar; kombine pipeline çalıştırıldığında ilk hata kodu `scripts/make-demo.sh` betiği tarafından terminalde yansıtılır.【F:packages/cli/src/index.ts†L116-L1140】
+
+## Ek Kaynaklar
+- `docs/demo_script.md`: Satış öncesi sunumlarda kullanılabilecek 5 dakikalık anlatım senaryosu.
+- `docs/architecture.md`: Paketler arası veri akışını açıklayan genel mimari şema.
+- `docs/deploy.md`: Üretim ortamı dağıtım önerileri.


### PR DESCRIPTION
## Summary
- add comprehensive user guide covering installation, usage, and CLI exit codes
- document security posture for signed manifests, key handling, and air-gap usage
- provide DO-330 tool assessment stub and customer acceptance checklist referencing demo artefacts

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68ce9fc0a47483288443cd7e4a3a6009