### PR TITLE
Add manifest signing to packaging workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ CLI paketini derleyip minimal örnek verilerle uçtan uca bir paket oluşturmak 
    node packages/cli/dist/index.js --license data/licenses/demo-license.key pack -i dist -o release --name soipack-demo.zip
    ```
 
+6. Manifest imzasını doğrulayın:
+
+   ```bash
+   node packages/cli/dist/index.js verify \
+     --manifest release/manifest.json \
+     --signature release/manifest.sig \
+     --public-key path/to/ed25519_public.pem
+   ```
+
+   Çıktı `Manifest imzası doğrulandı (ID: …)` şeklinde ise paket teslimat için hazırdır.
+
 Tek komutla tüm adımların çalıştığı pipeline için örnek yapılandırmayı kullanabilirsiniz:
 
 ```bash

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -121,6 +121,15 @@ BASE_URL=http://localhost:3000
      -d "{\"reportId\":\"<rapor-id>\"}"
    ```
 
+   Manifest ve imza dosyaları oluşturulduktan sonra teslimattan önce doğrulamak için üretim anahtarınızla aşağıdaki komutu çalıştırabilirsiniz:
+
+   ```bash
+   node packages/cli/dist/index.js verify \
+     --manifest data/packages/<paket-id>/manifest.json \
+     --signature data/packages/<paket-id>/manifest.sig \
+     --public-key path/to/ed25519_public.pem
+   ```
+
 ## 4. Güncelleme ve Bakım
 
 - Yeni bir sürüm yayınlandığında, hazırlık makinesinde `docker build` ve `docker save` adımlarını tekrar ederek yeni imajı içe aktarın.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,6 +57,13 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    cat <<'ENV' > .env
    SOIPACK_API_TOKEN=degiştir-beni
    PORT=3000
+   SOIPACK_STORAGE_DIR=/data/soipack
+   SOIPACK_SIGNING_KEY_PATH=/run/secrets/soipack-signing.pem
+   # Eski çıktıları otomatik temizlemek için gün bazında saklama süreleri (opsiyonel)
+   SOIPACK_RETENTION_UPLOADS_DAYS=14
+   SOIPACK_RETENTION_ANALYSES_DAYS=30
+   SOIPACK_RETENTION_REPORTS_DAYS=30
+   SOIPACK_RETENTION_PACKAGES_DAYS=60
    ENV
    ```
 4. Kalıcı depolama için `data/` dizinini kullanarak servisi başlatın:
@@ -69,7 +76,7 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    curl -H "Authorization: Bearer $SOIPACK_API_TOKEN" http://localhost:3000/health
    ```
 
-Sunucu sağlıklı dönerse çıktı `{"status":"ok"}` olacaktır. Tüm iş çıktıları (yüklemeler, analizler, raporlar ve paketler) `data/` dizininde saklanır ve konteyner yeniden başlatıldığında korunur.
+Sunucu sağlıklı dönerse çıktı `{"status":"ok"}` olacaktır. Tüm iş çıktıları (yüklemeler, analizler, raporlar ve paketler) varsayılan olarak `data/` dizininde saklanır ve konteyner yeniden başlatıldığında korunur. Dosya tabanlı depolama yerine PostgreSQL/S3 gibi alternatifleri tercih ediyorsanız `packages/server/src/storage.ts` altında tanımlı `StorageProvider` arayüzünü uygulayarak `createServer` fonksiyonuna özel bir sağlayıcı enjekte edebilirsiniz.
 
 ## 3. Örnek Pipeline Çağrısı
 
@@ -135,5 +142,6 @@ BASE_URL=http://localhost:3000
 - Yeni bir sürüm yayınlandığında, hazırlık makinesinde `docker build` ve `docker save` adımlarını tekrar ederek yeni imajı içe aktarın.
 - Kalıcı `data/` klasörünü düzenli olarak yedekleyin.
 - `docker compose logs -f server` komutu ile hata ayıklama günlüklerini takip edebilirsiniz.
+- Saklama politikaları ayarlıysa (örn. `SOIPACK_RETENTION_*_DAYS`), eski iş çıktıları `POST /v1/admin/cleanup` çağrısıyla temizlenir. JSON yanıtı hangi dizinlerden kaç kaydın silindiğini gösterir.
 
 Bu adımlar tamamlandığında air-gapped ortamda `docker compose up -d` komutuyla SOIPack API'si PDF/rapor üretecek şekilde hazır olacaktır.

--- a/docs/soipack_user_guide.md
+++ b/docs/soipack_user_guide.md
@@ -71,6 +71,14 @@ Aşağıdaki adımlar aynı çıktıları üretir ve kendi veri kümelerinizi ku
 
 Pipeline'ın YAML sürümü için `node packages/cli/dist/index.js --license data/licenses/demo-license.key run --config examples/minimal/soipack.config.yaml` komutunu çalıştırabilirsiniz; bu komut demo betiğinin tetiklediği konfigürasyonla aynıdır.【F:README.md†L36-L73】
 
+### Sunucu lisans doğrulaması
+SOIPack API'si, gönderilen her iş isteğinin geçerli bir lisans ile yetkilendirilmesini bekler. Uygulama başlatılırken `SOIPACK_LICENSE_PUBLIC_KEY_PATH` ortam değişkeni üzerinden Ed25519 kamu anahtarının base64 kodlu dosyası belirtilmelidir. İstemciler aşağıdaki yöntemlerden biriyle lisans anahtarını iletmelidir:
+
+- JSON tabanlı lisans dosyasını base64'e çevirip `X-SOIPACK-License` HTTP başlığına ekleyin. Örnek: ``cat license.key | base64`` çıktısını başlık değeri olarak kullanın.
+- `/v1/import` uç noktasına çok parçalı form gönderirken `license` alanına lisans dosyasını ekleyin; diğer uç noktalar yalnızca başlık yöntemini kabul eder.
+
+Geçersiz ya da süresi dolmuş lisanslar `402` durum kodu ve `LICENSE_INVALID` hata kodu ile reddedilir; lisans başlığı olmadan gönderilen isteklerde ise `401` durum kodu ve `LICENSE_REQUIRED` mesajı döner.
+
 ### Raporları inceleme
 Raporlar `dist/reports/` altında toplanır. `compliance_matrix.html` ve `trace_matrix.html` tarayıcıda açılarak müşteriye canlı demo yapılabilir; `compliance_matrix.pdf` aynı dizinde yer alır ve denetim arşivi için hazırdır.【F:docs/demo_script.md†L18-L25】 Paket arşivi, HTML/PDF raporlarını ve manifest dosyalarını `release/soi-pack-*.zip` içinde taşır.【F:docs/demo_script.md†L26-L31】
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/multer": "^1.4.12",
         "@types/node": "^20.11.19",
         "@types/supertest": "^2.0.16",
+        "@types/yazl": "^2.4.6",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
         "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@redocly/cli": "^1.16.0",
     "@types/jest": "^29.5.12",
     "@types/multer": "^1.4.12",
+    "@types/yazl": "^2.4.6",
     "@types/node": "^20.11.19",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/adapters/fixtures/cobertura/coverage.xml
+++ b/packages/adapters/fixtures/cobertura/coverage.xml
@@ -13,7 +13,7 @@
             </method>
           </methods>
           <lines>
-            <line number="10" hits="1" branch="false" />
+              <line number="10" hits="1" branch="false" tests="AuthSuite#passes" />
             <line number="11" hits="0" branch="true" condition-coverage="50% (1/2)" />
           </lines>
         </class>
@@ -26,7 +26,7 @@
             </method>
           </methods>
           <lines>
-            <line number="5" hits="1" branch="false" />
+              <line number="5" hits="1" branch="false" tests="AuditSuite#records" />
           </lines>
         </class>
       </classes>

--- a/packages/adapters/fixtures/lcov/lcov.info
+++ b/packages/adapters/fixtures/lcov/lcov.info
@@ -1,4 +1,4 @@
-TN:
+TN:AuthSuite#passes
 SF:/workspace/app/src/file1.ts
 DA:1,1
 DA:2,0
@@ -13,6 +13,7 @@ FNDA:1,doThing
 FNF:1
 FNH:1
 end_of_record
+TN:AuditSuite#records
 SF:/workspace/app/src/file2.ts
 DA:1,3
 LF:1

--- a/packages/adapters/src/index.test.ts
+++ b/packages/adapters/src/index.test.ts
@@ -88,6 +88,10 @@ describe('@soipack/adapters', () => {
     expect(data.totals.statements).toMatchObject({ covered: 2, total: 3, percentage: 66.67 });
     expect(data.totals.branches).toMatchObject({ covered: 1, total: 2, percentage: 50 });
     expect(data.totals.functions).toMatchObject({ covered: 1, total: 1, percentage: 100 });
+    expect(data.testMap).toEqual({
+      'AuthSuite#passes': ['/workspace/app/src/file1.ts'],
+      'AuditSuite#records': ['/workspace/app/src/file2.ts'],
+    });
   });
 
   it('imports Cobertura coverage summaries', async () => {
@@ -100,6 +104,10 @@ describe('@soipack/adapters', () => {
     expect(data.totals.statements).toMatchObject({ covered: 2, total: 3, percentage: 66.67 });
     expect(data.totals.branches).toMatchObject({ covered: 1, total: 2, percentage: 50 });
     expect(data.totals.functions).toMatchObject({ covered: 2, total: 2, percentage: 100 });
+    expect(data.testMap).toEqual({
+      'AuthSuite#passes': ['src/example.ts'],
+      'AuditSuite#records': ['src/other.ts'],
+    });
   });
 
   it('collects git metadata', async () => {

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -48,6 +48,7 @@ export interface CoverageSummary {
     functions?: CoverageMetric;
   };
   files: FileCoverageSummary[];
+  testMap?: Record<string, string[]>;
 }
 
 export interface BuildInfo {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,6 +59,7 @@ import {
   verifyLicenseFile,
   resolveLicensePath,
   type LicensePayload,
+  type VerifyLicenseOptions,
 } from './license';
 import { formatVersion } from './version';
 
@@ -1481,4 +1482,10 @@ if (require.main === module) {
   cli.parse();
 }
 
-export { exitCodes };
+export {
+  exitCodes,
+  verifyLicenseFile,
+  LicenseError,
+  type LicensePayload,
+  type VerifyLicenseOptions,
+};

--- a/packages/report/src/__fixtures__/goldens/compliance-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/compliance-matrix.html
@@ -266,6 +266,16 @@
             <strong>2</strong>
           </div>
         
+          <div class="summary-card">
+            <span>Kapsamlı Gereksinimler</span>
+            <strong>0/3</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Eksik/Kısmi Kapsam</span>
+            <strong>2/1</strong>
+          </div>
+        
       </div>
     </header>
     <main>
@@ -431,6 +441,90 @@
       </tbody>
     </table>
   </section>
+  
+    <section class="section">
+      <h2>Gereksinim Kapsamı</h2>
+      <p class="section-lead">
+        Testler ve kod izleri ile ilişkilendirilen gereksinimlerin kapsam durumunu gösterir. Yetersiz kapsama sahip alanları hızla tespit etmeyi sağlar.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Gereksinim</th>
+            <th>Kapsam Durumu</th>
+            <th>Kod Dosyaları</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+            <tr>
+              <td>
+                <div class="cell-title">REQ-AUTH-1</div>
+                <div class="cell-description">Çok faktörlü giriş sağlamalı</div>
+              </td>
+              <td>
+                <span class="badge status-partial">Kısmen Kaplandı</span>
+                
+                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                
+              </td>
+              <td>
+                
+                  <ul class="list">
+                    
+                      <li><code class="code-pill">src/auth/login.ts</code></li>
+                    
+                      <li><code class="code-pill">src/security/audit.ts</code></li>
+                    
+                  </ul>
+                
+              </td>
+            </tr>
+          
+            <tr>
+              <td>
+                <div class="cell-title">REQ-AUTH-2</div>
+                <div class="cell-description">Başarısız girişler kaydedilmeli</div>
+              </td>
+              <td>
+                <span class="badge status-partial">Kısmen Kaplandı</span>
+                
+                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                
+              </td>
+              <td>
+                
+                  <ul class="list">
+                    
+                      <li><code class="code-pill">src/auth/login.ts</code></li>
+                    
+                      <li><code class="code-pill">src/security/audit.ts</code></li>
+                    
+                  </ul>
+                
+              </td>
+            </tr>
+          
+            <tr>
+              <td>
+                <div class="cell-title">REQ-AUTH-3</div>
+                <div class="cell-description">Giriş ihlallerinde uyarı gönderilmeli</div>
+              </td>
+              <td>
+                <span class="badge status-missing">Kapsam Yok</span>
+                
+              </td>
+              <td>
+                
+                  <span class="muted">Kod bağlantısı yok</span>
+                
+              </td>
+            </tr>
+          
+        </tbody>
+      </table>
+    </section>
+  
     </main>
     <footer>
       <span>SOIPack Sürüm 0.1.0</span>

--- a/packages/report/src/__fixtures__/goldens/trace-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/trace-matrix.html
@@ -251,6 +251,16 @@
             <strong>4</strong>
           </div>
         
+          <div class="summary-card">
+            <span>Kapsamlı Gereksinimler</span>
+            <strong>0/3</strong>
+          </div>
+        
+          <div class="summary-card">
+            <span>Eksik/Kısmi Kapsam</span>
+            <strong>2/1</strong>
+          </div>
+        
       </div>
     </header>
     <main>
@@ -275,6 +285,14 @@
               <div class="cell-description">Çok faktörlü giriş sağlamalı</div>
               
                 <div class="muted">Durum: approved</div>
+              
+              
+                <div>
+                  <span class="badge status-partial">Kısmen Kaplandı</span>
+                  
+                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                  
+                </div>
               
             </td>
             <td>
@@ -326,6 +344,14 @@
               
                 <div class="muted">Durum: implemented</div>
               
+              
+                <div>
+                  <span class="badge status-partial">Kısmen Kaplandı</span>
+                  
+                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                  
+                </div>
+              
             </td>
             <td>
               
@@ -375,6 +401,12 @@
               <div class="cell-description">Giriş ihlallerinde uyarı gönderilmeli</div>
               
                 <div class="muted">Durum: draft</div>
+              
+              
+                <div>
+                  <span class="badge status-missing">Kapsam Yok</span>
+                  
+                </div>
               
             </td>
             <td>

--- a/packages/report/src/demo.ts
+++ b/packages/report/src/demo.ts
@@ -25,6 +25,7 @@ const main = async (): Promise<void> => {
   const traceHtml = renderTraceMatrix(fixture.traces, {
     manifestId: fixture.manifestId,
     title: 'SOIPack İzlenebilirlik Matrisi',
+    coverage: fixture.snapshot.requirementCoverage,
   });
   await fs.writeFile(path.join(outputDir, 'trace-matrix.html'), traceHtml, 'utf-8');
 

--- a/packages/report/src/index.test.ts
+++ b/packages/report/src/index.test.ts
@@ -33,6 +33,9 @@ describe('@soipack/report', () => {
     expect(result.json.manifestId).toBe(fixture.manifestId);
     expect(result.json.stats).toEqual(fixture.snapshot.stats);
     expect(result.json.objectives).toHaveLength(fixture.snapshot.objectives.length);
+    expect(result.json.requirementCoverage).toHaveLength(
+      fixture.snapshot.requirementCoverage.length,
+    );
 
     const goldenHtml = readFileSync(path.join(goldenDir, 'compliance-matrix.html'), 'utf-8');
     expect(hashHtml(result.html)).toBe(hashHtml(goldenHtml));
@@ -45,6 +48,7 @@ describe('@soipack/report', () => {
       manifestId: fixture.manifestId,
       title: 'Kurumsal İzlenebilirlik Matrisi',
       generatedAt: fixture.snapshot.generatedAt,
+      coverage: fixture.snapshot.requirementCoverage,
     });
 
     const goldenHtml = readFileSync(path.join(goldenDir, 'trace-matrix.html'), 'utf-8');

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -17,6 +17,15 @@ components:
       type: http
       scheme: bearer
       bearerFormat: Token
+  parameters:
+    LicenseHeader:
+      name: X-SOIPACK-License
+      in: header
+      required: false
+      description: |
+        Base64 kodlanmış lisans anahtarı. Import isteklerinde alternatif olarak `license` dosya alanı kullanılabilir.
+      schema:
+        type: string
   schemas:
     ErrorResponse:
       type: object
@@ -214,6 +223,8 @@ paths:
         Aynı dosya ve seçenek kombinasyonu tekrar gönderildiğinde aynı kimlikte sonuç üretir.
       security:
         - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LicenseHeader'
       requestBody:
         required: true
         content:
@@ -221,6 +232,10 @@ paths:
             schema:
               type: object
               properties:
+                license:
+                  type: string
+                  format: binary
+                  description: Lisans anahtarı dosyası. Başlıkla gönderilirse bu alan boş bırakılabilir.
                 jira:
                   type: string
                   format: binary
@@ -281,6 +296,8 @@ paths:
       summary: Çalışma alanından uyum analizi üretir.
       security:
         - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LicenseHeader'
       requestBody:
         required: true
         content:
@@ -331,6 +348,8 @@ paths:
       summary: Analiz çıktılarından rapor üretir.
       security:
         - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LicenseHeader'
       requestBody:
         required: true
         content:
@@ -376,6 +395,8 @@ paths:
       summary: Rapor çıktılarını arşivler.
       security:
         - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LicenseHeader'
       requestBody:
         required: true
         content:

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,0 +1,30 @@
+export class HttpError extends Error {
+  public readonly statusCode: number;
+
+  public readonly code: string;
+
+  public readonly details?: unknown;
+
+  constructor(statusCode: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export const toHttpError = (error: unknown, fallback?: { code?: string; message?: string; statusCode?: number }): HttpError => {
+  if (error instanceof HttpError) {
+    return error;
+  }
+  const message =
+    (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string')
+      ? (error as { message: string }).message
+      : String(error);
+
+  const statusCode = fallback?.statusCode ?? 500;
+  const code = fallback?.code ?? 'UNEXPECTED_ERROR';
+  const fallbackMessage = fallback?.message ?? 'Beklenmeyen bir hata oluştu.';
+
+  return new HttpError(statusCode, code, message || fallbackMessage);
+};

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -22,7 +22,32 @@ MCowBQYDK2VwAyEAOCPbC2Pxenbum50JoDbus/HoZnN2okit05G+z44CvK8=
 const minimalExample = (...segments: string[]): string =>
   path.resolve(__dirname, '../../..', 'examples', 'minimal', ...segments);
 
-jest.setTimeout(30000);
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitForJobCompletion = async (
+  app: ReturnType<typeof createServer>,
+  token: string,
+  jobId: string,
+) => {
+  let lastResponse: request.Response | undefined;
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const response = await request(app)
+      .get(`/v1/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    lastResponse = response;
+    if (response.body.status === 'completed') {
+      return response.body;
+    }
+    if (response.body.status === 'failed') {
+      throw new Error(`Job ${jobId} failed: ${JSON.stringify(response.body.error)}`);
+    }
+    await delay(250);
+  }
+  throw new Error(`Job ${jobId} did not complete in time: ${JSON.stringify(lastResponse?.body)}`);
+};
+
+jest.setTimeout(60000);
 
 describe('@soipack/server REST API', () => {
   const token = 'test-token';
@@ -46,8 +71,33 @@ describe('@soipack/server REST API', () => {
     expect(response.body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('executes pipeline end-to-end with idempotent stages', async () => {
-    const firstImport = await request(app)
+  it('processes pipeline jobs asynchronously with idempotent reuse', async () => {
+    const importResponse = await request(app)
+      .post('/v1/import')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('reqif', minimalExample('spec.reqif'))
+      .attach('junit', minimalExample('results.xml'))
+      .attach('lcov', minimalExample('lcov.info'))
+      .field('projectName', 'Minimal Project')
+      .field('projectVersion', '1.0.0')
+      .expect(202);
+
+    expect(importResponse.body.id).toHaveLength(16);
+    expect(importResponse.body.kind).toBe('import');
+    expect(['queued', 'running']).toContain(importResponse.body.status);
+    expect(importResponse.body.result).toBeUndefined();
+
+    const importJob = await waitForJobCompletion(app, token, importResponse.body.id);
+    expect(importJob.result.outputs.workspace).toMatch(/^workspaces\//);
+    expect(Array.isArray(importJob.result.warnings)).toBe(true);
+
+    const importList = await request(app)
+      .get('/v1/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(importList.body.jobs.some((job: { id: string }) => job.id === importResponse.body.id)).toBe(true);
+
+    const importReuse = await request(app)
       .post('/v1/import')
       .set('Authorization', `Bearer ${token}`)
       .attach('reqif', minimalExample('spec.reqif'))
@@ -57,73 +107,70 @@ describe('@soipack/server REST API', () => {
       .field('projectVersion', '1.0.0')
       .expect(200);
 
-    expect(firstImport.body.id).toHaveLength(16);
-    expect(firstImport.body.reused).toBe(false);
-    expect(Array.isArray(firstImport.body.warnings)).toBe(true);
+    expect(importReuse.body.id).toBe(importResponse.body.id);
+    expect(importReuse.body.reused).toBe(true);
+    expect(importReuse.body.result.outputs.workspace).toBe(importJob.result.outputs.workspace);
 
-    const secondImport = await request(app)
-      .post('/v1/import')
-      .set('Authorization', `Bearer ${token}`)
-      .attach('reqif', minimalExample('spec.reqif'))
-      .attach('junit', minimalExample('results.xml'))
-      .attach('lcov', minimalExample('lcov.info'))
-      .field('projectName', 'Minimal Project')
-      .field('projectVersion', '1.0.0')
-      .expect(200);
-
-    expect(secondImport.body.id).toBe(firstImport.body.id);
-    expect(secondImport.body.reused).toBe(true);
-
-    const analyzeResponse = await request(app)
+    const analyzeQueued = await request(app)
       .post('/v1/analyze')
       .set('Authorization', `Bearer ${token}`)
-      .send({ importId: firstImport.body.id })
-      .expect(200);
+      .send({ importId: importResponse.body.id })
+      .expect(202);
 
-    expect(analyzeResponse.body.id).toHaveLength(16);
-    expect(analyzeResponse.body.reused).toBe(false);
-    expect(typeof analyzeResponse.body.exitCode).toBe('number');
+    expect(analyzeQueued.body.kind).toBe('analyze');
+    expect(analyzeQueued.body.result).toBeUndefined();
 
-    const analyzeReused = await request(app)
+    const analyzeJob = await waitForJobCompletion(app, token, analyzeQueued.body.id);
+    expect(analyzeJob.result.outputs.snapshot).toMatch(/^analyses\//);
+    expect(typeof analyzeJob.result.exitCode).toBe('number');
+
+    const analyzeReuse = await request(app)
       .post('/v1/analyze')
       .set('Authorization', `Bearer ${token}`)
-      .send({ importId: firstImport.body.id })
+      .send({ importId: importResponse.body.id })
       .expect(200);
+    expect(analyzeReuse.body.reused).toBe(true);
+    expect(analyzeReuse.body.id).toBe(analyzeQueued.body.id);
 
-    expect(analyzeReused.body.id).toBe(analyzeResponse.body.id);
-    expect(analyzeReused.body.reused).toBe(true);
-
-    const reportResponse = await request(app)
+    const reportQueued = await request(app)
       .post('/v1/report')
       .set('Authorization', `Bearer ${token}`)
-      .send({ analysisId: analyzeResponse.body.id })
-      .expect(200);
+      .send({ analysisId: analyzeQueued.body.id })
+      .expect(202);
 
-    expect(reportResponse.body.reused).toBe(false);
-    expect(reportResponse.body.outputs.complianceHtml).toMatch(/^reports\//);
+    const reportJob = await waitForJobCompletion(app, token, reportQueued.body.id);
+    expect(reportJob.result.outputs.complianceHtml).toMatch(/^reports\//);
 
-    const reportReused = await request(app)
+    const reportReuse = await request(app)
       .post('/v1/report')
       .set('Authorization', `Bearer ${token}`)
-      .send({ analysisId: analyzeResponse.body.id })
+      .send({ analysisId: analyzeQueued.body.id })
       .expect(200);
+    expect(reportReuse.body.reused).toBe(true);
+    expect(reportReuse.body.id).toBe(reportQueued.body.id);
 
-    expect(reportReused.body.id).toBe(reportResponse.body.id);
-    expect(reportReused.body.reused).toBe(true);
-
-    const packResponse = await request(app)
+    const packQueued = await request(app)
       .post('/v1/pack')
       .set('Authorization', `Bearer ${token}`)
-      .send({ reportId: reportResponse.body.id })
+      .send({ reportId: reportQueued.body.id })
+      .expect(202);
+
+    const packJob = await waitForJobCompletion(app, token, packQueued.body.id);
+    expect(packJob.result.outputs.archive).toMatch(/^packages\//);
+    expect(packJob.result.manifestId).toHaveLength(12);
+
+    const packReuse = await request(app)
+      .post('/v1/pack')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ reportId: reportQueued.body.id })
       .expect(200);
+    expect(packReuse.body.reused).toBe(true);
+    expect(packReuse.body.id).toBe(packQueued.body.id);
 
-    expect(packResponse.body.manifestId).toHaveLength(12);
-    expect(packResponse.body.outputs.archive).toMatch(/^packages\//);
-
-    const archivePath = path.resolve(storageDir, packResponse.body.outputs.archive);
+    const archivePath = path.resolve(storageDir, packJob.result.outputs.archive);
     await expect(fsPromises.access(archivePath, fs.constants.F_OK)).resolves.toBeUndefined();
 
-    const manifestPath = path.resolve(storageDir, packResponse.body.outputs.manifest);
+    const manifestPath = path.resolve(storageDir, packJob.result.outputs.manifest);
     const manifestDir = path.dirname(manifestPath);
     const signaturePath = path.join(manifestDir, 'manifest.sig');
     const manifest = JSON.parse(await fsPromises.readFile(manifestPath, 'utf8')) as Manifest;
@@ -131,7 +178,7 @@ describe('@soipack/server REST API', () => {
     expect(verifyManifestSignature(manifest, signature, TEST_SIGNING_PUBLIC_KEY)).toBe(true);
 
     const reportAsset = await request(app)
-      .get(`/v1/reports/${reportResponse.body.id}/compliance.html`)
+      .get(`/v1/reports/${reportQueued.body.id}/compliance.html`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 

--- a/packages/server/src/queue.ts
+++ b/packages/server/src/queue.ts
@@ -1,0 +1,200 @@
+import { toHttpError } from './errors';
+
+type JobKind = 'import' | 'analyze' | 'report' | 'pack';
+
+type JobStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+interface JobErrorInfo {
+  statusCode: number;
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+interface InternalJob<T = unknown> {
+  id: string;
+  kind: JobKind;
+  hash: string;
+  status: JobStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  run?: () => Promise<T>;
+  result?: T;
+  error?: JobErrorInfo;
+}
+
+export interface JobSummary {
+  id: string;
+  kind: JobKind;
+  hash: string;
+  status: JobStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface JobDetails<T = unknown> extends JobSummary {
+  result?: T;
+  error?: JobErrorInfo;
+}
+
+interface EnqueueOptions<T> {
+  id: string;
+  kind: JobKind;
+  hash: string;
+  run: () => Promise<T>;
+}
+
+interface AdoptOptions<T> {
+  id: string;
+  kind: JobKind;
+  hash: string;
+  createdAt: string;
+  updatedAt?: string;
+  result: T;
+}
+
+export class JobQueue {
+  private readonly concurrency: number;
+
+  private readonly jobs = new Map<string, InternalJob<any>>();
+
+  private readonly order: InternalJob<any>[] = [];
+
+  private readonly pending: InternalJob<any>[] = [];
+
+  private active = 0;
+
+  constructor(concurrency = 1) {
+    this.concurrency = Math.max(1, concurrency);
+  }
+
+  public enqueue<T>({ id, kind, hash, run }: EnqueueOptions<T>): JobDetails<T> {
+    const existing = this.jobs.get(id);
+    if (existing) {
+      return this.toDetails(existing);
+    }
+
+    const createdAt = new Date();
+    const job: InternalJob<T> = {
+      id,
+      kind,
+      hash,
+      status: 'queued',
+      createdAt,
+      updatedAt: createdAt,
+      run,
+    };
+
+    this.jobs.set(id, job);
+    this.order.push(job);
+    this.pending.push(job);
+    this.process();
+
+    return this.toDetails(job);
+  }
+
+  public adoptCompleted<T>({ id, kind, hash, createdAt, updatedAt, result }: AdoptOptions<T>): JobDetails<T> {
+    const existing = this.jobs.get(id);
+    if (existing) {
+      if (existing.status === 'completed' && existing.result === undefined) {
+        existing.result = result;
+      }
+      return this.toDetails(existing);
+    }
+
+    const created = new Date(createdAt);
+    const updated = updatedAt ? new Date(updatedAt) : created;
+    const job: InternalJob<T> = {
+      id,
+      kind,
+      hash,
+      status: 'completed',
+      createdAt: created,
+      updatedAt: updated,
+      result,
+    };
+
+    this.jobs.set(id, job);
+    this.order.push(job);
+    return this.toDetails(job);
+  }
+
+  public list(): JobSummary[] {
+    return this.order.map((job) => this.toSummary(job));
+  }
+
+  public get<T = unknown>(id: string): JobDetails<T> | undefined {
+    const job = this.jobs.get(id);
+    if (!job) {
+      return undefined;
+    }
+    return this.toDetails(job) as JobDetails<T>;
+  }
+
+  private process(): void {
+    while (this.active < this.concurrency) {
+      const job = this.pending.shift();
+      if (!job) {
+        break;
+      }
+      if (!job.run) {
+        continue;
+      }
+
+      this.active += 1;
+      job.status = 'running';
+      job.updatedAt = new Date();
+
+      Promise.resolve()
+        .then(() => job.run!())
+        .then((result) => {
+          job.status = 'completed';
+          job.result = result;
+          job.updatedAt = new Date();
+        })
+        .catch((error) => {
+          const normalized = this.normalizeError(error);
+          job.status = 'failed';
+          job.error = normalized;
+          job.updatedAt = new Date();
+        })
+        .finally(() => {
+          this.active -= 1;
+          this.process();
+        });
+    }
+  }
+
+  private normalizeError(error: unknown): JobErrorInfo {
+    const httpError = toHttpError(error, {
+      code: 'JOB_FAILED',
+      message: 'İş başarısız oldu.',
+      statusCode: 500,
+    });
+    return {
+      statusCode: httpError.statusCode,
+      code: httpError.code,
+      message: httpError.message,
+      details: httpError.details,
+    };
+  }
+
+  private toSummary(job: InternalJob<any>): JobSummary {
+    return {
+      id: job.id,
+      kind: job.kind,
+      hash: job.hash,
+      status: job.status,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+    };
+  }
+
+  private toDetails<T>(job: InternalJob<T>): JobDetails<T> {
+    return {
+      ...this.toSummary(job),
+      result: job.result,
+      error: job.error,
+    };
+  }
+}

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -25,6 +25,13 @@ if (!signingKeyPathSource) {
   process.exit(1);
 }
 const signingKeyPath = path.resolve(signingKeyPathSource);
+const licensePublicKeyPathSource = process.env.SOIPACK_LICENSE_PUBLIC_KEY_PATH;
+if (!licensePublicKeyPathSource) {
+  // eslint-disable-next-line no-console
+  console.error('SOIPACK_LICENSE_PUBLIC_KEY_PATH ortam değişkeni tanımlanmalıdır.');
+  process.exit(1);
+}
+const licensePublicKeyPath = path.resolve(licensePublicKeyPathSource);
 const portSource = process.env.PORT ?? '3000';
 const port = Number.parseInt(portSource, 10);
 
@@ -75,7 +82,7 @@ if (packagesDays !== undefined) {
   retention.packages = { maxAgeMs: packagesDays };
 }
 
-const app = createServer({ token, storageDir, signingKeyPath, retention });
+const app = createServer({ token, storageDir, signingKeyPath, licensePublicKeyPath, retention });
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -18,6 +18,13 @@ if (!token) {
 const storageDir = process.env.SOIPACK_STORAGE_DIR
   ? path.resolve(process.env.SOIPACK_STORAGE_DIR)
   : path.resolve('.soipack/server');
+const signingKeyPathSource = process.env.SOIPACK_SIGNING_KEY_PATH;
+if (!signingKeyPathSource) {
+  // eslint-disable-next-line no-console
+  console.error('SOIPACK_SIGNING_KEY_PATH ortam değişkeni tanımlanmalıdır.');
+  process.exit(1);
+}
+const signingKeyPath = path.resolve(signingKeyPathSource);
 const portSource = process.env.PORT ?? '3000';
 const port = Number.parseInt(portSource, 10);
 
@@ -27,7 +34,7 @@ if (Number.isNaN(port) || port <= 0) {
   process.exit(1);
 }
 
-const app = createServer({ token, storageDir });
+const app = createServer({ token, storageDir, signingKeyPath });
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -1,0 +1,126 @@
+import fs, { promises as fsPromises } from 'fs';
+import path from 'path';
+
+import { HttpError } from './errors';
+
+export interface PipelineDirectories {
+  base: string;
+  uploads: string;
+  workspaces: string;
+  analyses: string;
+  reports: string;
+  packages: string;
+}
+
+export interface PersistableFile {
+  originalname: string;
+  buffer: Buffer;
+}
+
+export type UploadedFileMap = Record<string, PersistableFile[]>;
+
+const sanitizeFileName = (fileName: string, fallback: string): string => {
+  const baseName = path.basename(fileName || fallback);
+  const normalized = baseName.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return normalized || fallback;
+};
+
+export interface StorageProvider {
+  readonly directories: PipelineDirectories;
+  persistUploads(jobId: string, fileMap: UploadedFileMap): Promise<Record<string, string[]>>;
+  ensureDirectory(target: string): Promise<void>;
+  removeDirectory(target: string): Promise<void>;
+  fileExists(target: string): Promise<boolean>;
+  readJson<T>(filePath: string): Promise<T>;
+  writeJson(filePath: string, data: unknown): Promise<void>;
+  listSubdirectories(directory: string): Promise<string[]>;
+  toRelativePath(target: string): string;
+}
+
+export class FileSystemStorage implements StorageProvider {
+  public readonly directories: PipelineDirectories;
+
+  constructor(baseDir: string) {
+    const directories: PipelineDirectories = {
+      base: baseDir,
+      uploads: path.join(baseDir, 'uploads'),
+      workspaces: path.join(baseDir, 'workspaces'),
+      analyses: path.join(baseDir, 'analyses'),
+      reports: path.join(baseDir, 'reports'),
+      packages: path.join(baseDir, 'packages'),
+    };
+
+    this.directories = directories;
+    Object.values(directories).forEach((directory) => {
+      fs.mkdirSync(directory, { recursive: true });
+    });
+  }
+
+  public async persistUploads(
+    jobId: string,
+    fileMap: UploadedFileMap,
+  ): Promise<Record<string, string[]>> {
+    const entries = Object.entries(fileMap);
+    const result: Record<string, string[]> = {};
+    const jobUploadDir = path.join(this.directories.uploads, jobId);
+    await this.ensureDirectory(jobUploadDir);
+
+    for (const [field, files] of entries) {
+      for (const [index, file] of files.entries()) {
+        const targetDir = path.join(jobUploadDir, field);
+        await this.ensureDirectory(targetDir);
+        const safeName = sanitizeFileName(file.originalname, `${field}-${index}`);
+        const targetPath = path.join(targetDir, safeName);
+        await fsPromises.writeFile(targetPath, file.buffer);
+        if (!result[field]) {
+          result[field] = [];
+        }
+        result[field].push(targetPath);
+      }
+    }
+
+    return result;
+  }
+
+  public async ensureDirectory(target: string): Promise<void> {
+    await fsPromises.mkdir(target, { recursive: true });
+  }
+
+  public async removeDirectory(target: string): Promise<void> {
+    await fsPromises.rm(target, { recursive: true, force: true });
+  }
+
+  public async fileExists(target: string): Promise<boolean> {
+    try {
+      await fsPromises.access(target, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public async readJson<T>(filePath: string): Promise<T> {
+    const content = await fsPromises.readFile(filePath, 'utf8');
+    return JSON.parse(content) as T;
+  }
+
+  public async writeJson(filePath: string, data: unknown): Promise<void> {
+    const serialized = `${JSON.stringify(data, null, 2)}\n`;
+    await fsPromises.writeFile(filePath, serialized, 'utf8');
+  }
+
+  public async listSubdirectories(directory: string): Promise<string[]> {
+    const entries = await fsPromises.readdir(directory, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  }
+
+  public toRelativePath(target: string): string {
+    const resolvedBase = path.resolve(this.directories.base);
+    const resolvedTarget = path.resolve(target);
+    const relative = path.relative(resolvedBase, resolvedTarget);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new HttpError(500, 'PATH_OUT_OF_ROOT', 'Dosya yolu sunucu depolama alanının dışında.');
+    }
+    return relative.split(path.sep).join('/');
+  }
+}

--- a/scripts/e2e-api.ts
+++ b/scripts/e2e-api.ts
@@ -9,6 +9,11 @@ import { AddressInfo } from 'net';
 
 import { createServer } from '../packages/server/src/index';
 
+const DEMO_SIGNING_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEICiI0Jsw2AjCiWk2uBb89bIQkOH18XHytA2TtblwFzgQ
+-----END PRIVATE KEY-----
+`;
+
 const example = (...segments: string[]): string => path.resolve('examples', 'minimal', ...segments);
 
 const ensureOk = async <T>(response: Response): Promise<T> => {
@@ -42,7 +47,9 @@ interface PackResultBody {
 const main = async (): Promise<void> => {
   const token = process.env.SOIPACK_E2E_TOKEN ?? 'demo-token';
   const storageDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'soipack-api-e2e-'));
-  const app = createServer({ token, storageDir });
+  const signingKeyPath = path.join(storageDir, 'signing-key.pem');
+  await fsPromises.writeFile(signingKeyPath, DEMO_SIGNING_PRIVATE_KEY, 'utf8');
+  const app = createServer({ token, storageDir, signingKeyPath });
   const server = app.listen(0);
   await once(server, 'listening');
   const address = server.address() as AddressInfo;


### PR DESCRIPTION
## Summary
- refactor the CLI pack helper to build manifests with @soipack/packager, sign them with an Ed25519 key, and include the signature in archives
- add a signing key option to the pack and run commands with regression tests that validate signatures using a known public key
- require the server to load a configured signing key for /v1/pack and update supporting scripts and tests to verify signed packages

## Testing
- npx jest --config packages/cli/jest.config.cjs --runInBand
- npx jest --config packages/server/jest.config.cjs --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cea8841f188328baf0ac6e22153c4f