### PR TITLE
Add OIDC JWT authentication and tenant-aware storage enforcement

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,12 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      SOIPACK_API_TOKEN: ${SOIPACK_API_TOKEN:?SOIPACK_API_TOKEN tanımlanmalıdır}
+      SOIPACK_AUTH_ISSUER: ${SOIPACK_AUTH_ISSUER:?SOIPACK_AUTH_ISSUER tanımlanmalıdır}
+      SOIPACK_AUTH_AUDIENCE: ${SOIPACK_AUTH_AUDIENCE:?SOIPACK_AUTH_AUDIENCE tanımlanmalıdır}
+      SOIPACK_AUTH_JWKS_URI: ${SOIPACK_AUTH_JWKS_URI:?SOIPACK_AUTH_JWKS_URI tanımlanmalıdır}
+      SOIPACK_AUTH_TENANT_CLAIM: ${SOIPACK_AUTH_TENANT_CLAIM:-tenant}
+      SOIPACK_AUTH_USER_CLAIM: ${SOIPACK_AUTH_USER_CLAIM:-sub}
+      SOIPACK_AUTH_REQUIRED_SCOPES: ${SOIPACK_AUTH_REQUIRED_SCOPES:-soipack.api}
       SOIPACK_STORAGE_DIR: /app/data
       PORT: ${PORT:-3000}
     ports:
@@ -20,7 +25,7 @@ services:
         - CMD
         - node
         - -e
-        - "fetch('http://localhost:3000/health',{headers:{Authorization:'Bearer '+process.env.SOIPACK_API_TOKEN}}).then(res=>{if(!res.ok)process.exit(1);}).catch(()=>process.exit(1));"
+        - "const token=process.env.SOIPACK_HEALTHCHECK_TOKEN;if(!token){process.exit(1);}fetch('http://localhost:3000/health',{headers:{Authorization:'Bearer '+token}}).then(res=>{if(!res.ok)process.exit(1);}).catch(()=>process.exit(1));"
       interval: 30s
       timeout: 10s
       retries: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -8043,6 +8043,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -13002,6 +13011,7 @@
         "@soipack/report": "0.1.0",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
+        "jose": "^5.3.0",
         "multer": "^2.0.0"
       },
       "devDependencies": {

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -16,7 +16,8 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: Token
+      bearerFormat: JWT
+      description: OIDC sağlayıcısı tarafından imzalanmış, tenant kimliği içeren erişim belirteci.
   parameters:
     LicenseHeader:
       name: X-SOIPACK-License

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,7 @@
     "@soipack/core": "0.1.0",
     "@soipack/engine": "0.1.0",
     "@soipack/report": "0.1.0",
+    "jose": "^5.3.0",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "multer": "^2.0.0"


### PR DESCRIPTION
## Summary
- replace static API tokens with an OpenID Connect JWT middleware that validates issuer/audience, required scopes, and extracts tenant/user claims
- scope job metadata, queues, and storage paths by tenant to prevent cross-tenant access and ensure retention sweeps operate per tenant
- update tests, docs, tooling, and deployment scripts for JWT configuration, token expiry handling, and tenant-aware asset access

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68ceda6043508328b541c41568960f47