### PR TITLE
Add structured logging and metrics to server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1913,7 +1913,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -4080,6 +4079,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -9848,6 +9853,19 @@
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11447,6 +11465,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13012,7 +13039,9 @@
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "jose": "^5.3.0",
-        "multer": "^2.0.0"
+        "multer": "^2.0.0",
+        "pino": "^8.21.0",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/multer": "^1.4.12"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,10 +10,12 @@
     "@soipack/core": "0.1.0",
     "@soipack/engine": "0.1.0",
     "@soipack/report": "0.1.0",
-    "jose": "^5.3.0",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "multer": "^2.0.0"
+    "jose": "^5.3.0",
+    "multer": "^2.0.0",
+    "pino": "^8.21.0",
+    "prom-client": "^15.1.3"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",


### PR DESCRIPTION
## Summary
- integrate pino logging and Prometheus metrics into the server job pipeline, including a protected /metrics endpoint
- add comprehensive tests covering logging and metrics for success and failure flows
- document the new observability capabilities in the deployment guide

## Testing
- npm test --workspace packages/server

------
https://chatgpt.com/codex/tasks/task_b_68cee85f2fb88328923ad48f4e7674cc