### PR TITLE
Enhance git metadata reporting

### DIFF
--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -64,4 +64,8 @@ export interface BuildInfo {
   author: string;
   date: string;
   message: string;
+  branches: string[];
+  tags: string[];
+  dirty: boolean;
+  remoteOrigins: string[];
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -701,6 +701,7 @@ export const runReport = async (options: ReportOptions): Promise<ReportResult> =
     title: analysis.metadata.project?.name
       ? `${analysis.metadata.project.name} Uyum Matrisi`
       : 'SOIPack Uyum Matrisi',
+    git: analysis.git,
   });
   const traceHtml = renderTraceMatrix(traces, {
     generatedAt: analysis.metadata.generatedAt,
@@ -708,6 +709,7 @@ export const runReport = async (options: ReportOptions): Promise<ReportResult> =
       ? `${analysis.metadata.project.name} İzlenebilirlik Matrisi`
       : 'SOIPack İzlenebilirlik Matrisi',
     coverage: snapshot.requirementCoverage,
+    git: analysis.git,
   });
   const gapsHtml = renderGaps(snapshot, {
     objectivesMetadata: analysis.objectives,
@@ -716,6 +718,7 @@ export const runReport = async (options: ReportOptions): Promise<ReportResult> =
     title: analysis.metadata.project?.name
       ? `${analysis.metadata.project.name} Kanıt Boşlukları`
       : 'SOIPack Uyumluluk Boşlukları',
+    git: analysis.git,
   });
 
   const outputDir = path.resolve(options.output);

--- a/packages/report/src/__fixtures__/goldens/compliance-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/compliance-matrix.html
@@ -36,6 +36,31 @@
     margin: 0;
     font-size: 14px;
     opacity: 0.9;
+    word-break: break-word;
+    line-height: 1.4;
+  }
+
+  .report-meta + .report-meta {
+    margin-top: 4px;
+  }
+
+  .report-meta-flag {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(248, 113, 113, 0.35);
+    color: #fee2e2;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .git-meta {
+    margin-top: 16px;
+    display: grid;
+    gap: 4px;
   }
 
   .summary-grid {
@@ -233,6 +258,19 @@
         
         <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
         <p class="report-meta">Rapor Tarihi: 2024-02-01 12:00 UTC</p>
+        <div class="git-meta">
+          <p class="report-meta">
+            Commit:
+            <strong>
+              <abbr title="1234567890abcdef1234567890abcdef12345678">1234567890ab</abbr>
+            </strong>
+          </p>
+          <p class="report-meta">Dallar: main</p>
+          <p class="report-meta">Etiketler: v1.0.0</p>
+          <p class="report-meta">Origin: https://example.com/repo.git</p>
+          <p class="report-meta">Yazar: Example Dev • 2024-02-01 09:00 UTC</p>
+          <p class="report-meta">Mesaj: Add avionics tests</p>
+        </div>
       </div>
       <div class="summary-grid">
         

--- a/packages/report/src/__fixtures__/goldens/gaps.html
+++ b/packages/report/src/__fixtures__/goldens/gaps.html
@@ -36,6 +36,31 @@
     margin: 0;
     font-size: 14px;
     opacity: 0.9;
+    word-break: break-word;
+    line-height: 1.4;
+  }
+
+  .report-meta + .report-meta {
+    margin-top: 4px;
+  }
+
+  .report-meta-flag {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(248, 113, 113, 0.35);
+    color: #fee2e2;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .git-meta {
+    margin-top: 16px;
+    display: grid;
+    gap: 4px;
   }
 
   .summary-grid {
@@ -233,6 +258,19 @@
         
         <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
         <p class="report-meta">Rapor Tarihi: 2024-02-01 12:00 UTC</p>
+        <div class="git-meta">
+          <p class="report-meta">
+            Commit:
+            <strong>
+              <abbr title="1234567890abcdef1234567890abcdef12345678">1234567890ab</abbr>
+            </strong>
+          </p>
+          <p class="report-meta">Dallar: main</p>
+          <p class="report-meta">Etiketler: v1.0.0</p>
+          <p class="report-meta">Origin: https://example.com/repo.git</p>
+          <p class="report-meta">Yazar: Example Dev • 2024-02-01 09:00 UTC</p>
+          <p class="report-meta">Mesaj: Add avionics tests</p>
+        </div>
       </div>
       <div class="summary-grid">
         

--- a/packages/report/src/__fixtures__/goldens/trace-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/trace-matrix.html
@@ -36,6 +36,31 @@
     margin: 0;
     font-size: 14px;
     opacity: 0.9;
+    word-break: break-word;
+    line-height: 1.4;
+  }
+
+  .report-meta + .report-meta {
+    margin-top: 4px;
+  }
+
+  .report-meta-flag {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(248, 113, 113, 0.35);
+    color: #fee2e2;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .git-meta {
+    margin-top: 16px;
+    display: grid;
+    gap: 4px;
   }
 
   .summary-grid {
@@ -233,6 +258,19 @@
         
         <p class="report-meta">Kanıt Manifest ID: <strong>MAN-TR-2024-0001</strong></p>
         <p class="report-meta">Rapor Tarihi: 2024-02-01 12:00 UTC</p>
+        <div class="git-meta">
+          <p class="report-meta">
+            Commit:
+            <strong>
+              <abbr title="1234567890abcdef1234567890abcdef12345678">1234567890ab</abbr>
+            </strong>
+          </p>
+          <p class="report-meta">Dallar: main</p>
+          <p class="report-meta">Etiketler: v1.0.0</p>
+          <p class="report-meta">Origin: https://example.com/repo.git</p>
+          <p class="report-meta">Yazar: Example Dev • 2024-02-01 09:00 UTC</p>
+          <p class="report-meta">Mesaj: Add avionics tests</p>
+        </div>
       </div>
       <div class="summary-grid">
         


### PR DESCRIPTION
## Summary
- extend the git adapter to capture branch names, tag pointers, remote origin URLs, and dirty working tree warnings while enriching the BuildInfo payload
- surface the richer git metadata through the CLI workspace/report pipeline and render commit context in report headers with updated styling
- cover the new behaviour with adapter fixtures for clean/dirty/tagged repositories and update report golden/tests to expect the commit details

## Testing
- npm run test --workspace @soipack/adapters *(fails: fast-xml-parser module missing in test environment)*
- npm run test --workspace @soipack/report *(fails: playwright module missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ceff00c8a083288ec30e61facfce10