### PR TITLE
feat: support manual trace link imports

### DIFF
--- a/packages/cli/src/__fixtures__/manual-links/issues.csv
+++ b/packages/cli/src/__fixtures__/manual-links/issues.csv
@@ -1,0 +1,4 @@
+Issue key,Summary,Status,Priority
+REQ-1,Authenticate valid users,Done,High
+REQ-2,Handle locked accounts,In Progress,Medium
+REQ-3,Log authentication attempts,To Do,Low

--- a/packages/cli/src/__fixtures__/manual-links/lcov.info
+++ b/packages/cli/src/__fixtures__/manual-links/lcov.info
@@ -1,0 +1,12 @@
+TN:AuthTests#validates login
+SF:src/auth/login.ts
+DA:1,1
+LF:1
+LH:1
+end_of_record
+TN:AuthTests#handles lockout
+SF:src/auth/login.ts
+DA:1,1
+LF:1
+LH:1
+end_of_record

--- a/packages/cli/src/__fixtures__/manual-links/results.xml
+++ b/packages/cli/src/__fixtures__/manual-links/results.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="AuthTests">
+  <testcase classname="AuthTests" name="validates login" time="1.0" id="AuthTests#validates login">
+    <properties>
+      <property name="requirements" value="REQ-1" />
+    </properties>
+  </testcase>
+  <testcase classname="AuthTests" name="handles lockout" time="1.1" id="AuthTests#handles lockout" />
+</testsuite>

--- a/packages/cli/src/__fixtures__/manual-links/trace-links.csv
+++ b/packages/cli/src/__fixtures__/manual-links/trace-links.csv
@@ -1,0 +1,3 @@
+from,to,type
+REQ-1,AuthTests#validates login,verifies
+REQ-2,AuthTests#handles lockout,verifies

--- a/packages/cli/src/__fixtures__/manual-links/trace-links.json
+++ b/packages/cli/src/__fixtures__/manual-links/trace-links.json
@@ -1,0 +1,6 @@
+{
+  "links": [
+    { "from": "REQ-2", "to": "AuthTests#handles lockout", "type": "verifies" },
+    { "from": "REQ-3", "to": "src/auth/login.ts", "type": "implements" }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow the CLI import workflow to parse manual trace link CSV/JSON files, merge them with generated links, and record conflicts as warnings
- extend the trace engine to honor requirement-to-code links and add fixtures/tests that cover manual link ingestion and deduplication
- expose the new manual trace link inputs through the CLI options, workspace bundle handling, and server upload policies

## Testing
- npm run build -- --pretty false
- npx jest --config packages/cli/jest.config.cjs --runTestsByPath packages/cli/src/index.test.ts --runInBand *(fails: ts-jest could not resolve optional dependency `yazl` during test compilation)*
- npx jest --config packages/engine/jest.config.cjs --runTestsByPath packages/engine/src/index.test.ts --runInBand *(fails: ts-jest could not resolve peer dependency `zod` in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cf03105bfc83288be302fd6191942a