### PR TITLE
Stream package artifacts via authenticated endpoints

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -134,7 +134,7 @@ BASE_URL=http://localhost:3000
    ```
    Yanıttaki `outputs.directory` alanı, `data/` altında oluşturulan rapor klasörünü gösterir. Örneğin `data/reports/<rapor-id>/compliance_matrix.pdf` dosyasını açarak PDF üretimini doğrulayabilirsiniz.
 
-4. (İsteğe bağlı) Raporu paketleyin:
+4. (İsteğe bağlı) Raporu paketleyin ve arşiv/manifesti indirin:
    ```bash
    curl -X POST "$BASE_URL/v1/pack" \
      -H "Authorization: Bearer $TOKEN" \
@@ -142,12 +142,35 @@ BASE_URL=http://localhost:3000
      -d "{\"reportId\":\"<rapor-id>\"}"
    ```
 
-   Manifest ve imza dosyaları oluşturulduktan sonra teslimattan önce doğrulamak için üretim anahtarınızla aşağıdaki komutu çalıştırabilirsiniz:
+   Yanıtın `id` alanını `PACKAGE_ID` olarak kaydedin. Paket arşivi ile manifesti JWT kimlik doğrulamasıyla çekmek için:
 
    ```bash
+   curl -H "Authorization: Bearer $TOKEN" \
+     "$BASE_URL/v1/packages/$PACKAGE_ID/archive" \
+     --output soipack-$PACKAGE_ID.zip
+
+   curl -H "Authorization: Bearer $TOKEN" \
+     "$BASE_URL/v1/packages/$PACKAGE_ID/manifest" \
+     --output manifest-$PACKAGE_ID.json
+   ```
+
+   Aynı işlem CLI üzerinden de yapılabilir:
+
+   ```bash
+   node packages/cli/dist/index.js download \
+     --api "$BASE_URL" \
+     --token "$TOKEN" \
+     --package "$PACKAGE_ID" \
+     --output artifacts/
+   ```
+
+   Arşiv içinde yer alan `manifest.sig` dosyası ile indirilen manifesti teslimat öncesinde doğrulamak için:
+
+   ```bash
+   unzip artifacts/soipack-$PACKAGE_ID.zip manifest.sig
    node packages/cli/dist/index.js verify \
-     --manifest data/packages/<paket-id>/manifest.json \
-     --signature data/packages/<paket-id>/manifest.sig \
+     --manifest manifest-$PACKAGE_ID.json \
+     --signature manifest.sig \
      --public-key path/to/ed25519_public.pem
    ```
 

--- a/docs/soipack_acceptance_checklist.md
+++ b/docs/soipack_acceptance_checklist.md
@@ -16,6 +16,8 @@ Bu kontrol listesi, SOIPack demo paketinin müşteri veya denetçi tesliminden �
 ## Paket ve Güvenlik
 - [ ] `release/manifest.json` ve `manifest.sig` dosyaları saklandı; hash doğrulaması bağımsız olarak tekrarlandı.【F:docs/demo_script.md†L26-L31】
 - [ ] `release/soi-pack-*.zip` arşivi açılarak raporların ve manifestlerin paket içinde bulunduğu teyit edildi.【F:docs/demo_script.md†L26-L31】
+- [ ] `/v1/packages/<paket-id>/archive` ve `/v1/packages/<paket-id>/manifest` uç noktaları yetkili token ile test edildi; farklı tenant token'ı erişim sağlayamadı.【F:packages/server/src/index.ts†L1462-L1493】【F:packages/server/src/index.test.ts†L706-L744】
+- [ ] `node packages/cli/dist/index.js download --api <URL> --token <TOKEN> --package <paket-id>` komutu ile arşiv ve manifest indirildi; çıktılar teslimat paketine eklendi.【F:packages/cli/src/index.ts†L1437-L1564】
 - [ ] Anahtar yönetimi prosedürleri `docs/soipack_security.md` ile uyumlu şekilde belgelenmiş ve müşteriye iletilmiştir.【F:docs/soipack_security.md†L1-L64】
 
 ## Teslimat

--- a/package-lock.json
+++ b/package-lock.json
@@ -5100,12 +5100,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -7486,12 +7480,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9186,54 +9174,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jszip/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/jszip/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9276,15 +9216,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -10414,12 +10345,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11033,12 +10958,6 @@
       "engines": {
         "node": ">= 0.6.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/process-warning": {
       "version": "3.0.0",
@@ -11957,12 +11876,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -14507,7 +14420,6 @@
       "version": "0.1.0",
       "dependencies": {
         "file-saver": "^2.0.5",
-        "jszip": "^3.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -136,7 +136,11 @@ export interface PrintToPdfOptions extends BaseReportOptions {
   };
 }
 
-const env = new nunjucks.Environment(undefined, { autoescape: true });
+const env = new nunjucks.Environment(undefined, {
+  autoescape: true,
+  trimBlocks: true,
+  lstripBlocks: true,
+});
 
 const statusLabels: Record<ComplianceSnapshot['objectives'][number]['status'], string> = {
   covered: 'Tam Karşılandı',
@@ -555,12 +559,7 @@ const layoutTemplate = nunjucks.compile(
               <p class="report-meta">Origin: {{ git.remoteOrigins | join(', ') }}</p>
             {% endif %}
             {% if git.author or git.formattedDate %}
-              <p class="report-meta">
-                {% if git.author %}Yazar: {{ git.author }}{% endif %}
-                {% if git.formattedDate %}
-                  {% if git.author %} • {% endif %}{{ git.formattedDate }}
-                {% endif %}
-              </p>
+              <p class="report-meta">{% if git.author %}Yazar: {{ git.author }}{% if git.formattedDate %} • {% endif %}{% endif %}{% if git.formattedDate %}{{ git.formattedDate }}{% endif %}</p>
             {% endif %}
             {% if git.message %}
               <p class="report-meta">Mesaj: {{ git.message }}</p>

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -243,9 +243,10 @@ components:
         - type: object
           properties:
             result:
-              type: object
-              nullable: true
-              additionalProperties: true
+              oneOf:
+                - type: object
+                  additionalProperties: true
+                - type: 'null'
             error:
               oneOf:
                 - $ref: '#/components/schemas/JobError'
@@ -759,6 +760,7 @@ paths:
     get:
       operationId: downloadPackage
       summary: Oluşturulmuş paket arşivini indirir.
+      deprecated: true
       security:
         - BearerAuth: []
       parameters:
@@ -784,6 +786,82 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Paket bulunamadı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/packages/{id}/archive:
+    get:
+      operationId: downloadPackageArchive
+      summary: Paket arşiv dosyasını doğrudan indirir.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-f0-9]{16}$'
+      responses:
+        '200':
+          description: Paket arşiv dosyası.
+          headers:
+            Content-Disposition:
+              description: İndirilen dosya adı.
+              schema:
+                type: string
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Paket bulunamadı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/packages/{id}/manifest:
+    get:
+      operationId: downloadPackageManifest
+      summary: Paket manifest dosyasını indirir.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-f0-9]{16}$'
+      responses:
+        '200':
+          description: Manifest dosyası.
+          headers:
+            Content-Disposition:
+              description: Manifest dosya adı.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Manifest bulunamadı.
           content:
             application/json:
               schema:

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -31,6 +31,8 @@ export interface StorageProvider {
   ensureDirectory(target: string): Promise<void>;
   removeDirectory(target: string): Promise<void>;
   fileExists(target: string): Promise<boolean>;
+  openReadStream(target: string): Promise<NodeJS.ReadableStream>;
+  getFileInfo(target: string): Promise<{ size?: number } | undefined>;
   readJson<T>(filePath: string): Promise<T>;
   writeJson(filePath: string, data: unknown): Promise<void>;
   listSubdirectories(directory: string): Promise<string[]>;
@@ -97,6 +99,19 @@ export class FileSystemStorage implements StorageProvider {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  public async openReadStream(target: string): Promise<NodeJS.ReadableStream> {
+    return fs.createReadStream(target);
+  }
+
+  public async getFileInfo(target: string): Promise<{ size?: number } | undefined> {
+    try {
+      const stats = await fsPromises.stat(target);
+      return { size: stats.size };
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "jszip": "^3.10.1",
     "file-saver": "^2.0.5"
   },
   "devDependencies": {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
   const isTokenActive = token.trim().length > 0;
   const { runPipeline, downloadArtifacts, state, reset } = usePipeline(token);
 
-  const { logs, isRunning, isDownloading, jobs, reportData, reportAssets, error, lastCompletedAt } = state;
+  const { logs, isRunning, isDownloading, jobs, reportData, packageJob, error, lastCompletedAt } = state;
 
   const canRunPipeline = selectedFiles.length > 0;
 
@@ -40,7 +40,7 @@ export default function App() {
 
   const jobStates = useMemo(
     () =>
-      (['import', 'analyze', 'report'] as const)
+      (['import', 'analyze', 'report', 'pack'] as const)
         .map((kind) => {
           const job = jobs[kind];
           if (!job) {
@@ -82,7 +82,7 @@ export default function App() {
           </div>
           <DownloadPackageButton
             onDownload={() => downloadArtifacts()}
-            disabled={!isTokenActive || !reportAssets}
+            disabled={!isTokenActive || !packageJob || packageJob.status !== 'completed'}
             isBusy={isDownloading}
           />
         </header>

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -6,6 +6,7 @@ import {
   type ReportAssetMap,
   type ReportJobResult,
   type RequirementTracePayload,
+  type PackJobResult,
 } from '../types/pipeline';
 
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
@@ -236,6 +237,32 @@ export const reportArtifacts = async ({
   return readJson<ApiJob<ReportJobResult>>(response);
 };
 
+interface PackOptions {
+  token: string;
+  reportId: string;
+  packageName?: string;
+  signal?: AbortSignal;
+}
+
+export const packArtifacts = async ({
+  token,
+  reportId,
+  packageName,
+  signal,
+}: PackOptions): Promise<ApiJob<PackJobResult>> => {
+  const response = await fetch(joinUrl('/v1/pack'), {
+    method: 'POST',
+    headers: {
+      ...buildAuthHeaders(token),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ reportId, packageName }),
+    signal,
+  });
+
+  return readJson<ApiJob<PackJobResult>>(response);
+};
+
 interface GetJobOptions {
   token: string;
   jobId: string;
@@ -358,6 +385,42 @@ export const fetchReportAsset = async ({
   signal,
 }: FetchAssetOptions): Promise<Response> => {
   const response = await fetch(joinUrl(`/v1/reports/${reportId}/${asset}`), {
+    method: 'GET',
+    headers: buildAuthHeaders(token),
+    signal,
+  });
+
+  await ensureOk(response);
+  return response;
+};
+
+interface FetchPackageOptions {
+  token: string;
+  packageId: string;
+  signal?: AbortSignal;
+}
+
+export const fetchPackageArchive = async ({
+  token,
+  packageId,
+  signal,
+}: FetchPackageOptions): Promise<Response> => {
+  const response = await fetch(joinUrl(`/v1/packages/${packageId}/archive`), {
+    method: 'GET',
+    headers: buildAuthHeaders(token),
+    signal,
+  });
+
+  await ensureOk(response);
+  return response;
+};
+
+export const fetchPackageManifest = async ({
+  token,
+  packageId,
+  signal,
+}: FetchPackageOptions): Promise<Response> => {
+  const response = await fetch(joinUrl(`/v1/packages/${packageId}/manifest`), {
     method: 'GET',
     headers: buildAuthHeaders(token),
     signal,

--- a/packages/ui/src/types/pipeline.ts
+++ b/packages/ui/src/types/pipeline.ts
@@ -63,6 +63,15 @@ export interface ReportJobResult {
   };
 }
 
+export interface PackJobResult {
+  manifestId: string;
+  outputs: {
+    directory: string;
+    manifest: string;
+    archive: string;
+  };
+}
+
 export interface ComplianceRequirementCoverage {
   requirementId: string;
   title?: string;

--- a/scripts/e2e-api.ts
+++ b/scripts/e2e-api.ts
@@ -29,25 +29,97 @@ const ensureOk = async <T>(response: Response): Promise<T> => {
   return (await response.json()) as T;
 };
 
-interface ImportResultBody {
-  id: string;
+type JobStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+interface JobError {
+  code: string;
+  message: string;
+  details?: unknown;
 }
 
-interface AnalyzeResultBody {
-  id: string;
+interface ImportJobResult {
+  warnings: string[];
+  outputs: {
+    directory: string;
+    workspace: string;
+  };
+}
+
+interface AnalyzeJobResult {
   exitCode: number;
+  outputs: {
+    directory: string;
+    snapshot: string;
+    traces: string;
+    analysis: string;
+  };
 }
 
-interface ReportResultBody {
-  id: string;
-  outputs: { complianceHtml: string };
+interface ReportJobResult {
+  outputs: {
+    directory: string;
+    complianceHtml: string;
+    complianceJson: string;
+    traceHtml: string;
+    gapsHtml: string;
+    analysis: string;
+    snapshot: string;
+    traces: string;
+  };
 }
 
-interface PackResultBody {
-  id: string;
+interface PackJobResult {
   manifestId: string;
-  outputs: { archive: string };
+  outputs: {
+    directory: string;
+    manifest: string;
+    archive: string;
+  };
 }
+
+interface JobResponse<T> {
+  id: string;
+  kind: string;
+  hash: string;
+  status: JobStatus;
+  createdAt: string;
+  updatedAt: string;
+  reused?: boolean;
+  result?: T;
+  error?: JobError;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const waitForJobCompletion = async <T>(
+  baseUrl: string,
+  token: string,
+  jobId: string,
+): Promise<JobResponse<T>> => {
+  let lastBody: JobResponse<T> | undefined;
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const response = await fetch(`${baseUrl}/v1/jobs/${jobId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Job durumu alınamadı (${response.status}): ${text}`);
+    }
+    const body = (await response.json()) as JobResponse<T>;
+    lastBody = body;
+    if (body.status === 'completed') {
+      return body;
+    }
+    if (body.status === 'failed') {
+      throw new Error(`İş ${jobId} başarısız: ${JSON.stringify(body.error)}`);
+    }
+    await sleep(250);
+  }
+  throw new Error(`İş ${jobId} zaman aşımına uğradı: ${JSON.stringify(lastBody)}`);
+};
 
 const main = async (): Promise<void> => {
   const storageDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'soipack-api-e2e-'));
@@ -110,34 +182,68 @@ const main = async (): Promise<void> => {
       headers: baseHeaders,
       body: formData,
     });
-    const importResult = await ensureOk<ImportResultBody>(importResponse);
-    console.log(`Import tamamlandı: ${importResult.id}`);
+    const importQueued = await ensureOk<JobResponse<ImportJobResult>>(importResponse);
+    const importJob =
+      importQueued.status === 'completed'
+        ? importQueued
+        : await waitForJobCompletion<ImportJobResult>(baseUrl, token, importQueued.id);
+    console.log(`Import tamamlandı: ${importJob.id}`);
 
     const analyzeResponse = await fetch(`${baseUrl}/v1/analyze`, {
       method: 'POST',
       headers: { ...baseHeaders, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ importId: importResult.id }),
+      body: JSON.stringify({ importId: importJob.id }),
     });
-    const analyzeResult = await ensureOk<AnalyzeResultBody>(analyzeResponse);
-    console.log(`Analyze tamamlandı: ${analyzeResult.id} (exitCode=${analyzeResult.exitCode})`);
+    const analyzeQueued = await ensureOk<JobResponse<AnalyzeJobResult>>(analyzeResponse);
+    const analyzeJob =
+      analyzeQueued.status === 'completed'
+        ? analyzeQueued
+        : await waitForJobCompletion<AnalyzeJobResult>(baseUrl, token, analyzeQueued.id);
+    console.log(`Analyze tamamlandı: ${analyzeJob.id} (exitCode=${analyzeJob.result?.exitCode ?? 'unknown'})`);
 
     const reportResponse = await fetch(`${baseUrl}/v1/report`, {
       method: 'POST',
       headers: { ...baseHeaders, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ analysisId: analyzeResult.id }),
+      body: JSON.stringify({ analysisId: analyzeJob.id }),
     });
-    const reportResult = await ensureOk<ReportResultBody>(reportResponse);
-    console.log(`Report üretildi: ${reportResult.id}`);
+    const reportQueued = await ensureOk<JobResponse<ReportJobResult>>(reportResponse);
+    const reportJob =
+      reportQueued.status === 'completed'
+        ? reportQueued
+        : await waitForJobCompletion<ReportJobResult>(baseUrl, token, reportQueued.id);
+    console.log(`Report üretildi: ${reportJob.id}`);
 
     const packResponse = await fetch(`${baseUrl}/v1/pack`, {
       method: 'POST',
       headers: { ...baseHeaders, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ reportId: reportResult.id }),
+      body: JSON.stringify({ reportId: reportJob.id }),
     });
-    const packResult = await ensureOk<PackResultBody>(packResponse);
-    console.log(`Pack tamamlandı: ${packResult.id} (manifest=${packResult.manifestId})`);
+    const packQueued = await ensureOk<JobResponse<PackJobResult>>(packResponse);
+    const packJob =
+      packQueued.status === 'completed'
+        ? packQueued
+        : await waitForJobCompletion<PackJobResult>(baseUrl, token, packQueued.id);
+    console.log(`Pack tamamlandı: ${packJob.id} (manifest=${packJob.result?.manifestId ?? 'n/a'})`);
 
-    const assetResponse = await fetch(`${baseUrl}/v1/reports/${reportResult.id}/compliance.html`, {
+    const archiveResponse = await fetch(`${baseUrl}/v1/packages/${packJob.id}/archive`, {
+      headers: { Authorization: baseHeaders.Authorization },
+    });
+    if (!archiveResponse.ok) {
+      throw new Error(`Paket arşivi indirilemedi: ${archiveResponse.status}`);
+    }
+    const archiveBytes = await archiveResponse.arrayBuffer();
+    console.log(`Paket arşivi ${archiveBytes.byteLength} bayt indirildi.`);
+
+    const manifestResponse = await fetch(`${baseUrl}/v1/packages/${packJob.id}/manifest`, {
+      headers: { Authorization: baseHeaders.Authorization },
+    });
+    if (!manifestResponse.ok) {
+      throw new Error(`Manifest indirilemedi: ${manifestResponse.status}`);
+    }
+    const manifestContent = await manifestResponse.json();
+    console.log(`Manifest ${Object.keys(manifestContent).length} anahtar içeriyor.`);
+
+    const assetResponse = await fetch(`${baseUrl}/v1/reports/${reportJob.id}/compliance.html`, {
       headers: baseHeaders,
     });
     if (!assetResponse.ok) {


### PR DESCRIPTION
## Summary
- add streaming helpers to the server so `/v1/packages/:id/archive` and `/v1/packages/:id/manifest` return scoped artifacts with correct headers and tenant checks
- expose the new download routes through the CLI `download` command, UI pipeline hook, and integration tests while removing the client-side zipping flow
- document the updated download process, extend the acceptance checklist, and harden the API e2e script to await job completion before fetching artifacts

## Testing
- npm test
- npm run openapi:validate
- npm run e2e:api

------
https://chatgpt.com/codex/tasks/task_b_68cf0b6dad3c83288efe6350bb039893