### PR TITLE
Ensure docker deployment secrets are enforced

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,11 +14,16 @@ services:
       SOIPACK_AUTH_USER_CLAIM: ${SOIPACK_AUTH_USER_CLAIM:-sub}
       SOIPACK_AUTH_REQUIRED_SCOPES: ${SOIPACK_AUTH_REQUIRED_SCOPES:-soipack.api}
       SOIPACK_STORAGE_DIR: /app/data
+      SOIPACK_SIGNING_KEY_PATH: /run/secrets/soipack-signing.pem
+      SOIPACK_LICENSE_PUBLIC_KEY_PATH: /run/secrets/soipack-license.pub
+      SOIPACK_HEALTHCHECK_TOKEN: ${SOIPACK_HEALTHCHECK_TOKEN:?SOIPACK_HEALTHCHECK_TOKEN tanımlanmalıdır}
       PORT: ${PORT:-3000}
     ports:
       - "3000:3000"
     volumes:
       - ./data:/app/data
+      # ./secrets klasöründe soipack-signing.pem ve soipack-license.pub dosyalarını bekler
+      - ./secrets:/run/secrets:ro
     restart: unless-stopped
     healthcheck:
       test:

--- a/packages/server/src/deploy-config.test.ts
+++ b/packages/server/src/deploy-config.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+describe('docker-compose deployment configuration', () => {
+  it('defines required secrets and health check configuration', () => {
+    const composePath = resolve(__dirname, '../../../docker-compose.yaml');
+    const file = readFileSync(composePath, 'utf8');
+    const compose = parse(file) as {
+      services: Record<string, { environment?: Record<string, string>; volumes?: string[] }>;
+    };
+
+    const server = compose.services?.server;
+    expect(server).toBeDefined();
+
+    expect(server?.environment).toMatchObject({
+      SOIPACK_SIGNING_KEY_PATH: '/run/secrets/soipack-signing.pem',
+      SOIPACK_LICENSE_PUBLIC_KEY_PATH: '/run/secrets/soipack-license.pub',
+      SOIPACK_HEALTHCHECK_TOKEN:
+        '${SOIPACK_HEALTHCHECK_TOKEN:?SOIPACK_HEALTHCHECK_TOKEN tanımlanmalıdır}',
+    });
+
+    expect(server?.volumes).toEqual(
+      expect.arrayContaining(['./secrets:/run/secrets:ro'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- require the server container to mount signing and license keys and define the health-check token at startup
- add a Jest regression test that parses docker-compose.yaml and asserts the expected env vars and secrets volume exist
- document preparing the secrets directory, required environment variables, and license header usage throughout the deployment guide

## Testing
- npm test -- --runInBand
- npx jest --selectProjects server --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cfa42d498883289d3b157167626c04