### PR TITLE
Enforce HTTPS for downloads and cover new CLI flag

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -184,6 +184,8 @@ BASE_URL=http://localhost:3000
      --output artifacts/
    ```
 
+   CLI varsayılan olarak yalnızca HTTPS taban adreslerinden indirmeye izin verir; güvenli olmayan `http://` uç noktaları için geliştirici ortamlarında `--allow-insecure-http` bayrağını özellikle eklemeniz gerekir.
+
    Arşiv içinde yer alan `manifest.sig` dosyası ile indirilen manifesti teslimat öncesinde doğrulamak için:
 
    ```bash

--- a/docs/soipack_user_guide.md
+++ b/docs/soipack_user_guide.md
@@ -69,6 +69,20 @@ Aşağıdaki adımlar aynı çıktıları üretir ve kendi veri kümelerinizi ku
    node packages/cli/dist/index.js --license data/licenses/demo-license.key pack -i dist -o release --name soipack-demo.zip
    ```
 
+### Paket artefaktlarını indirme
+
+Pipeline sunucusu tarafından üretilen arşiv ve manifest dosyalarını almak için `download` alt komutu kullanılabilir:
+
+```bash
+node packages/cli/dist/index.js --license data/licenses/demo-license.key download \
+  --api https://soipack.example.com \
+  --token $TOKEN \
+  --package $PACKAGE_ID \
+  --output artifacts/
+```
+
+İndirilecek URL'ler varsayılan olarak HTTPS olmak zorundadır; CLI, `http://` taban adresleri güvenli olmadığı için reddeder. Yalnızca yerel geliştirme ortamlarında gerekli olduğunda `--allow-insecure-http` bayrağını global argüman olarak ekleyerek HTTP'ye geçici olarak izin verebilirsiniz.
+
 Pipeline'ın YAML sürümü için `node packages/cli/dist/index.js --license data/licenses/demo-license.key run --config examples/minimal/soipack.config.yaml` komutunu çalıştırabilirsiniz; bu komut demo betiğinin tetiklediği konfigürasyonla aynıdır.【F:README.md†L36-L73】
 
 ### Sunucu lisans doğrulaması


### PR DESCRIPTION
## Summary
- require HTTPS downloads by parsing URLs with `new URL`, enforcing a timeout, and allowing opt-in HTTP overrides
- plumb a global `--allow-insecure-http` flag through the CLI download helpers
- extend CLI tests and docs to cover the new behavior and usage guidance

## Testing
- npm test -- --runTestsByPath packages/cli/src/index.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cfa99bba848328910f16d7f01ac1f2