### PR TITLE
feat(server): validate signing key path on startup

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -90,6 +90,8 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
 
    `SOIPACK_SIGNING_KEY_PATH` ve `SOIPACK_LICENSE_PUBLIC_KEY_PATH` değerleri, üçüncü adımda oluşturduğunuz `/run/secrets` bağlamasındaki `soipack-signing.pem` ve `soipack-license.pub` dosyalarına işaret eder. `SOIPACK_HEALTHCHECK_TOKEN` boş bırakılamaz; konteynerdeki sağlık kontrolü komutu aynı bearer token'ı kullanır.
 
+   Sunucu başlatma betiği, `SOIPACK_SIGNING_KEY_PATH` tarafından işaret edilen PEM dosyasının okunabilirliğini baştan doğrular. Dosya yanlış bağlanmışsa veya izinler sebebiyle erişilemiyorsa hizmet `SOIPACK_SIGNING_KEY_PATH ile belirtilen anahtar dosyasına erişilemiyor` hatasıyla hemen durur.
+
    Tüm HTTP istekleri için lisans dosyasını base64'e çevirerek `X-SOIPACK-License` başlığına ekleyin. Örneklerde kullanılan `license.key`, lisans sağlayıcısından aldığınız JSON dosyasının ham halidir.
 5. Kalıcı depolama için `data/` dizinini kullanarak servisi başlatın:
    ```bash

--- a/packages/server/src/start.test.ts
+++ b/packages/server/src/start.test.ts
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('resolveSigningKeyPath', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  const loadHelper = async () => {
+    const module = await import('./start');
+    return module.resolveSigningKeyPath;
+  };
+
+  it('exits when signing key path env is missing', async () => {
+    delete process.env.SOIPACK_SIGNING_KEY_PATH;
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code ?? 0}`);
+      }) as never);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resolveSigningKeyPath = await loadHelper();
+
+    await expect(resolveSigningKeyPath()).rejects.toThrow('process.exit: 1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith('SOIPACK_SIGNING_KEY_PATH ortam değişkeni tanımlanmalıdır.');
+  });
+
+  it('exits when signing key path is unreadable', async () => {
+    process.env.SOIPACK_SIGNING_KEY_PATH = 'non-existent.pem';
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code ?? 0}`);
+      }) as never);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resolveSigningKeyPath = await loadHelper();
+
+    await expect(resolveSigningKeyPath()).rejects.toThrow('process.exit: 1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('SOIPACK_SIGNING_KEY_PATH ile belirtilen anahtar dosyasına erişilemiyor:'),
+    );
+  });
+
+  it('returns resolved path when signing key is accessible', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'soipack-start-test-'));
+    const keyPath = path.join(tmpDir, 'signing.pem');
+    await fs.promises.writeFile(keyPath, 'dummy');
+    process.env.SOIPACK_SIGNING_KEY_PATH = keyPath;
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code ?? 0}`);
+      }) as never);
+
+    const resolveSigningKeyPath = await loadHelper();
+
+    await expect(resolveSigningKeyPath()).resolves.toBe(path.resolve(keyPath));
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper that resolves and verifies the signing key path before configuring the server
- reuse the helper in the startup flow so the service aborts early when the PEM is missing or unreadable
- cover the new behaviour with Jest tests and document the upfront check in the deployment guide

## Testing
- npm test -- --selectProjects server --runTestsByPath packages/server/src/start.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cfadff284c83289173732ac2d56d72