### PR TITLE
feat(server): enforce tenant queue limits

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -75,6 +75,8 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    SOIPACK_STORAGE_DIR=/data/soipack
    SOIPACK_SIGNING_KEY_PATH=/run/secrets/soipack-signing.pem
    SOIPACK_LICENSE_PUBLIC_KEY_PATH=/run/secrets/soipack-license.pub
+   # Kiracı başına kuyrukta bekleyen/çalışan iş limiti (opsiyonel, varsayılan 5)
+   SOIPACK_MAX_QUEUED_JOBS=5
    # Antivirüs komut satırı entegrasyonu (örn. ClamAV)
    SOIPACK_SCAN_COMMAND=/usr/bin/clamdscan
    SOIPACK_SCAN_ARGS=--fdpass,--no-summary
@@ -93,6 +95,8 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    Sunucu başlatma betiği, `SOIPACK_SIGNING_KEY_PATH` tarafından işaret edilen PEM dosyasının okunabilirliğini baştan doğrular. Dosya yanlış bağlanmışsa veya izinler sebebiyle erişilemiyorsa hizmet `SOIPACK_SIGNING_KEY_PATH ile belirtilen anahtar dosyasına erişilemiyor` hatasıyla hemen durur.
 
    Tüm HTTP istekleri için lisans dosyasını base64'e çevirerek `X-SOIPACK-License` başlığına ekleyin. Örneklerde kullanılan `license.key`, lisans sağlayıcısından aldığınız JSON dosyasının ham halidir.
+
+   Kuyruk limiti her kiracı için eşzamanlı olarak kuyruğa alınan veya çalışan işlerin üst sınırını belirler. Varsayılan değer 5'tir; daha yüksek değerler daha yoğun iş yüklerine izin verirken, aynı anda yürütülen import/analiz işlemlerinin CPU ve disk üzerindeki etkilerini de artırır. Limit aşıldığında API `429 QUEUE_LIMIT_EXCEEDED` hatası döner ve ilgili kiracı için yeni işler kuyruğa alınmaz; istemciler mevcut işlerden biri tamamlandıktan sonra yeniden denemelidir.
 5. Kalıcı depolama için `data/` dizinini kullanarak servisi başlatın:
    ```bash
    docker compose up -d

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -44,6 +44,8 @@ const parseRetentionDays = (value: string | undefined, label: string): number | 
   return parsed * 24 * 60 * 60 * 1000;
 };
 
+const DEFAULT_MAX_QUEUED_JOBS_PER_TENANT = 5;
+
 const start = async (): Promise<void> => {
   const authIssuer = process.env.SOIPACK_AUTH_ISSUER;
   if (!authIssuer) {
@@ -129,6 +131,18 @@ const start = async (): Promise<void> => {
     process.exit(1);
   }
 
+  const maxQueuedJobsSource = process.env.SOIPACK_MAX_QUEUED_JOBS;
+  let maxQueuedJobsPerTenant = DEFAULT_MAX_QUEUED_JOBS_PER_TENANT;
+  if (maxQueuedJobsSource !== undefined) {
+    const parsed = Number.parseInt(maxQueuedJobsSource, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      // eslint-disable-next-line no-console
+      console.error('SOIPACK_MAX_QUEUED_JOBS pozitif bir tam sayı olmalıdır.');
+      process.exit(1);
+    }
+    maxQueuedJobsPerTenant = parsed;
+  }
+
   const retention: RetentionConfig = {};
 
   const uploadsDays = parseRetentionDays(
@@ -209,6 +223,7 @@ const start = async (): Promise<void> => {
     storageDir,
     signingKeyPath,
     licensePublicKeyPath,
+    maxQueuedJobsPerTenant,
     retention,
     scanner,
   });


### PR DESCRIPTION
## Summary
- add maxQueuedJobsPerTenant option to the server and surface SOIPACK_MAX_QUEUED_JOBS configuration
- enforce tenant-scoped queue depth before enqueuing new jobs and emit 429 errors when the limit is reached
- cover queue limiting behavior with new Jest tests and document the sizing guidance in the deployment guide

## Testing
- npx jest --config packages/server/jest.config.cjs --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cfb397a38c8328b825e9220146bb7d