### PR TITLE
Validate pack package names

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -166,6 +166,8 @@ BASE_URL=http://localhost:3000
      -d "{\"reportId\":\"<rapor-id>\"}"
    ```
 
+   İsteğe bağlı `packageName` alanı gönderilecekse değer yalnızca harf/rakam, nokta, alt çizgi veya tire içeren ve `.zip` ile biten düz bir dosya adı olmalıdır (ör. `release.zip`). Yol gezinme dizileri (`../hack.zip`) veya mutlak yollar reddedilir.
+
    Yanıtın `id` alanını `PACKAGE_ID` olarak kaydedin. Paket arşivi ile manifesti JWT kimlik doğrulamasıyla çekmek için:
 
    ```bash

--- a/packages/cli/src/@types/yazl/index.d.ts
+++ b/packages/cli/src/@types/yazl/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'yazl';

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -507,7 +507,8 @@ paths:
                   type: string
                 packageName:
                   type: string
-                  description: Oluşturulacak zip dosyası adı.
+                  description: Oluşturulacak zip dosyası adı. Yalnızca `.zip` uzantılı ve harf/rakam, nokta, alt çizgi veya tire içeren düz dosya adları kabul edilir.
+                  pattern: '^[A-Za-z0-9][A-Za-z0-9._-]*\.zip$'
       responses:
         '200':
           description: Paket başarıyla oluşturuldu.


### PR DESCRIPTION
## Summary
- sanitize CLI pack archive names and expose a shared normalizer for reuse by the server
- reject unsafe package names in the /v1/pack route and exercise the behaviour in CLI and server tests
- document the allowed archive name pattern in the OpenAPI schema and deployment guide

## Testing
- npm test --workspace @soipack/cli -- --runInBand
- npm test --workspace @soipack/server -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cfbd150ac48328a53c3c2320ef47aa