### PR TITLE
Enforce admin scopes for privileged server endpoints

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       SOIPACK_AUTH_TENANT_CLAIM: ${SOIPACK_AUTH_TENANT_CLAIM:-tenant}
       SOIPACK_AUTH_USER_CLAIM: ${SOIPACK_AUTH_USER_CLAIM:-sub}
       SOIPACK_AUTH_REQUIRED_SCOPES: ${SOIPACK_AUTH_REQUIRED_SCOPES:-soipack.api}
+      SOIPACK_AUTH_ADMIN_SCOPES: ${SOIPACK_AUTH_ADMIN_SCOPES:-soipack.admin}
       SOIPACK_STORAGE_DIR: /app/data
       SOIPACK_SIGNING_KEY_PATH: /run/secrets/soipack-signing.pem
       SOIPACK_LICENSE_PUBLIC_KEY_PATH: /run/secrets/soipack-license.pub

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,6 +69,7 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    SOIPACK_AUTH_TENANT_CLAIM=tenant
    SOIPACK_AUTH_USER_CLAIM=sub
    SOIPACK_AUTH_REQUIRED_SCOPES=soipack.api
+   SOIPACK_AUTH_ADMIN_SCOPES=soipack.admin
    # Sağlık kontrolü için zorunlu bearer token (örn. uzun ömürlü JWT)
    SOIPACK_HEALTHCHECK_TOKEN=
    PORT=3000
@@ -89,6 +90,8 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    SOIPACK_RETENTION_PACKAGES_DAYS=60
    ENV
    ```
+
+   `SOIPACK_AUTH_ADMIN_SCOPES`, virgülle ayrılmış yönetici kapsamlarını tanımlar. Liste boş değilse yalnızca bu kapsamların en az birine sahip belirteçler yönetici uç noktalarına (`POST /v1/admin/cleanup` ve `/metrics`) erişebilir. İş yüklerini tetikleyen kullanıcılarla gözlemleme/bakım ekiplerini ayrıştırmak için ayrı bir erişim scope'u tanımlamanız önerilir.
 
    `SOIPACK_SIGNING_KEY_PATH` ve `SOIPACK_LICENSE_PUBLIC_KEY_PATH` değerleri, üçüncü adımda oluşturduğunuz `/run/secrets` bağlamasındaki `soipack-signing.pem` ve `soipack-license.pub` dosyalarına işaret eder. `SOIPACK_HEALTHCHECK_TOKEN` boş bırakılamaz; konteynerdeki sağlık kontrolü komutu aynı bearer token'ı kullanır.
 
@@ -209,7 +212,7 @@ BASE_URL=http://localhost:3000
 - Yeni bir sürüm yayınlandığında, hazırlık makinesinde `docker build` ve `docker save` adımlarını tekrar ederek yeni imajı içe aktarın.
 - Kalıcı `data/` klasörünü düzenli olarak yedekleyin.
 - `docker compose logs -f server` komutu ile hata ayıklama günlüklerini takip edebilirsiniz.
-- Saklama politikaları ayarlıysa (örn. `SOIPACK_RETENTION_*_DAYS`), eski iş çıktıları `POST /v1/admin/cleanup` çağrısıyla temizlenir. JSON yanıtı hangi dizinlerden kaç kaydın silindiğini gösterir.
+- Saklama politikaları ayarlıysa (örn. `SOIPACK_RETENTION_*_DAYS`), eski iş çıktıları `POST /v1/admin/cleanup` çağrısıyla temizlenir. Bu uç noktaya erişim için `SOIPACK_AUTH_ADMIN_SCOPES` listesindeki kapsamların en az biri gerekir. JSON yanıtı hangi dizinlerden kaç kaydın silindiğini gösterir.
 
 ## 5. Gözlemlenebilirlik
 
@@ -219,7 +222,7 @@ BASE_URL=http://localhost:3000
   - `job_reused`: Aynı parametrelerle oluşturulmuş önceki bir iş yeniden kullanıldığında.
   - `job_failed`: İş çalışırken hata aldığında (HTTP hata kodu ve ayrıntılar dahil).
   Bu günlükleri `docker compose logs -f server` veya kendi log toplayıcınıza yönlendirerek inceleyebilirsiniz.
-- Prometheus uyumlu metrikler `/metrics` uç noktasından sunulur ve diğer API çağrıları gibi JWT ile kimlik doğrulaması gerektirir:
+- Prometheus uyumlu metrikler `/metrics` uç noktasından sunulur ve diğer API çağrıları gibi, ayrıca `SOIPACK_AUTH_ADMIN_SCOPES` listesinden en az bir kapsam içeren bir JWT ile kimlik doğrulaması gerektirir:
   ```bash
   curl -H "Authorization: Bearer $TOKEN" \
     -H "X-SOIPACK-License: $(base64 -w0 license.key)" \

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -867,3 +867,98 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /v1/admin/cleanup:
+    post:
+      operationId: runRetentionCleanup
+      summary: Saklama politikalarına göre eski iş çıktılarının temizliğini tetikler.
+      description: |-
+        Yalnızca yönetici kapsamına sahip belirteçlerle çağrılabilir. `SOIPACK_AUTH_ADMIN_SCOPES`
+        listesinde tanımlanan kapsamların en az birine sahip erişim belirteci gerektirir.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Temizlik işlemi özeti.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - summary
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                  summary:
+                    type: array
+                    description: Her saklama hedefi için temizlenen/korunan kayıt sayıları.
+                    items:
+                      type: object
+                      required:
+                        - target
+                        - removed
+                        - retained
+                        - skipped
+                        - configured
+                      properties:
+                        target:
+                          type: string
+                          description: Saklama politikası hedefi.
+                          enum:
+                            - uploads
+                            - analyses
+                            - reports
+                            - packages
+                        removed:
+                          type: integer
+                          minimum: 0
+                        retained:
+                          type: integer
+                          minimum: 0
+                        skipped:
+                          type: integer
+                          minimum: 0
+                        configured:
+                          type: boolean
+        '401':
+          description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Yönetici kapsamı eksik.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /metrics:
+    get:
+      operationId: getMetrics
+      summary: Prometheus formatında gözlemlenebilirlik metriklerini döner.
+      description: |-
+        Yalnızca yönetici kapsamına sahip belirteçlerle çağrılabilir. `SOIPACK_AUTH_ADMIN_SCOPES`
+        listesinde tanımlanan kapsamların en az birine sahip erişim belirteci gerektirir.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Prometheus metrikleri.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '401':
+          description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Yönetici kapsamı eksik.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -75,6 +75,10 @@ const start = async (): Promise<void> => {
     ?.split(',')
     .map((scope) => scope.trim())
     .filter((scope) => scope.length > 0);
+  const authAdminScopes = process.env.SOIPACK_AUTH_ADMIN_SCOPES
+    ?.split(',')
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
 
   const clockToleranceSource = process.env.SOIPACK_AUTH_CLOCK_TOLERANCE_SECONDS;
   let authClockToleranceSeconds: number | undefined;
@@ -103,6 +107,9 @@ const start = async (): Promise<void> => {
   }
   if (authRequiredScopes && authRequiredScopes.length > 0) {
     authConfig.requiredScopes = authRequiredScopes;
+  }
+  if (authAdminScopes && authAdminScopes.length > 0) {
+    authConfig.adminScopes = authAdminScopes;
   }
   if (authClockToleranceSeconds !== undefined) {
     authConfig.clockToleranceSeconds = authClockToleranceSeconds;


### PR DESCRIPTION
## Summary
- allow configuring optional admin scopes via SOIPACK_AUTH_ADMIN_SCOPES and surface admin access in the auth context
- require admin scope for /v1/admin/cleanup and /metrics, with new tests validating both denied and successful calls
- document the new configuration, update docker-compose defaults, and extend OpenAPI specs for the privileged endpoints

## Testing
- npm test --workspace @soipack/server -- --runTestsByPath src/index.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cfc0945b588328ae183007475fe578