### PR TITLE
Require health check bearer token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,13 @@ jobs:
             -e SOIPACK_SIGNING_KEY_PATH=/run/secrets/signing-key.pem \
             -e SOIPACK_LICENSE_PUBLIC_KEY_PATH=/run/secrets/license.pub \
             -e SOIPACK_STORAGE_DIR=/tmp/soipack \
+            -e SOIPACK_HEALTHCHECK_TOKEN=ci-health-token \
             -e PORT=3000 \
             soipack/server
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://localhost:3000/health; then
+            if curl --fail --silent --show-error \
+              -H "Authorization: Bearer ci-health-token" \
+              http://localhost:3000/health; then
               docker rm -f soipack-ci >/dev/null 2>&1 || true
               exit 0
             fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,15 @@ services:
     restart: unless-stopped
     healthcheck:
       test:
-        - CMD
-        - node
-        - -e
-        - "const token=process.env.SOIPACK_HEALTHCHECK_TOKEN;if(!token){process.exit(1);}fetch('http://localhost:3000/health',{headers:{Authorization:'Bearer '+token}}).then(res=>{if(!res.ok)process.exit(1);}).catch(()=>process.exit(1));"
+        - CMD-SHELL
+        - >-
+          node -e "const token=process.env.SOIPACK_HEALTHCHECK_TOKEN;
+          if(!token){process.exit(1);}
+          fetch('http://localhost:3000/health', {
+            headers: { Authorization: 'Bearer ' + token }
+          }).then((res) => {
+            if(!res.ok){process.exit(1);}
+          }).catch(() => process.exit(1));"
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -93,7 +93,7 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
 
    `SOIPACK_AUTH_ADMIN_SCOPES`, virgülle ayrılmış yönetici kapsamlarını tanımlar. Liste boş değilse yalnızca bu kapsamların en az birine sahip belirteçler yönetici uç noktalarına (`POST /v1/admin/cleanup` ve `/metrics`) erişebilir. İş yüklerini tetikleyen kullanıcılarla gözlemleme/bakım ekiplerini ayrıştırmak için ayrı bir erişim scope'u tanımlamanız önerilir.
 
-   `SOIPACK_SIGNING_KEY_PATH` ve `SOIPACK_LICENSE_PUBLIC_KEY_PATH` değerleri, üçüncü adımda oluşturduğunuz `/run/secrets` bağlamasındaki `soipack-signing.pem` ve `soipack-license.pub` dosyalarına işaret eder. `SOIPACK_HEALTHCHECK_TOKEN` boş bırakılamaz; konteynerdeki sağlık kontrolü komutu aynı bearer token'ı kullanır.
+   `SOIPACK_SIGNING_KEY_PATH` ve `SOIPACK_LICENSE_PUBLIC_KEY_PATH` değerleri, üçüncü adımda oluşturduğunuz `/run/secrets` bağlamasındaki `soipack-signing.pem` ve `soipack-license.pub` dosyalarına işaret eder. `SOIPACK_HEALTHCHECK_TOKEN` boş bırakılamaz; konteynerdeki sağlık kontrolü komutu aynı bearer token'ı kullanır ve sunucu bu değer tanımlandığında `/health` uç noktasına gelen isteklerin `Authorization: Bearer <token>` başlığını içermesini zorunlu kılar. Başlık eksik ya da hatalıysa API `401 UNAUTHORIZED` döner.
 
    Sunucu başlatma betiği, `SOIPACK_SIGNING_KEY_PATH` tarafından işaret edilen PEM dosyasının okunabilirliğini baştan doğrular. Dosya yanlış bağlanmışsa veya izinler sebebiyle erişilemiyorsa hizmet `SOIPACK_SIGNING_KEY_PATH ile belirtilen anahtar dosyasına erişilemiyor` hatasıyla hemen durur.
 
@@ -104,7 +104,7 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
    ```bash
    docker compose up -d
    ```
-6. Sağlık kontrolünü doğrulayın (geçerli bir JWT üretmek için OIDC sağlayıcınızı kullanın; `.env` dosyasındaki `SOIPACK_HEALTHCHECK_TOKEN` değerinin aynı olması gerekir):
+6. Sağlık kontrolünü doğrulayın (geçerli bir JWT veya uzun ömürlü servis belirteci üretmek için OIDC sağlayıcınızı kullanın; `.env` dosyasındaki `SOIPACK_HEALTHCHECK_TOKEN` değerinin aynı olması gerekir):
    ```bash
    docker compose ps
    TOKEN=$(./jwt-olustur.sh) # örnek: kendi betiğiniz veya sağlayıcı SDK'sı
@@ -113,7 +113,7 @@ Bu belge, internet bağlantısı olmayan ("air-gapped") ortamlarda SOIPack REST 
      http://localhost:3000/health
    ```
 
-Sunucu sağlıklı dönerse çıktı `{"status":"ok"}` olacaktır. Tüm iş çıktıları (yüklemeler, analizler, raporlar ve paketler) varsayılan olarak `data/` dizininde saklanır ve konteyner yeniden başlatıldığında korunur. Dosya tabanlı depolama yerine PostgreSQL/S3 gibi alternatifleri tercih ediyorsanız `packages/server/src/storage.ts` altında tanımlı `StorageProvider` arayüzünü uygulayarak `createServer` fonksiyonuna özel bir sağlayıcı enjekte edebilirsiniz.
+Sunucu sağlıklı dönerse çıktı `{"status":"ok"}` olacaktır; yanlış veya eksik bearer başlığı `401 UNAUTHORIZED` sonucu verir. Tüm iş çıktıları (yüklemeler, analizler, raporlar ve paketler) varsayılan olarak `data/` dizininde saklanır ve konteyner yeniden başlatıldığında korunur. Dosya tabanlı depolama yerine PostgreSQL/S3 gibi alternatifleri tercih ediyorsanız `packages/server/src/storage.ts` altında tanımlı `StorageProvider` arayüzünü uygulayarak `createServer` fonksiyonuna özel bir sağlayıcı enjekte edebilirsiniz.
 
 ## 3. Örnek Pipeline Çağrısı
 

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -138,6 +138,8 @@ const start = async (): Promise<void> => {
     process.exit(1);
   }
 
+  const healthcheckToken = process.env.SOIPACK_HEALTHCHECK_TOKEN;
+
   const maxQueuedJobsSource = process.env.SOIPACK_MAX_QUEUED_JOBS;
   let maxQueuedJobsPerTenant = DEFAULT_MAX_QUEUED_JOBS_PER_TENANT;
   if (maxQueuedJobsSource !== undefined) {
@@ -233,6 +235,7 @@ const start = async (): Promise<void> => {
     maxQueuedJobsPerTenant,
     retention,
     scanner,
+    healthcheckToken,
   });
 
   app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add optional health check token configuration and require the Authorization header on `/health`
- exercise successful and failure paths for the health endpoint in server tests
- update CI, docker health checks, and deployment docs to send the configured bearer token

## Testing
- npm run test -- --runTestsByPath packages/server/src/index.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cfc3cf0e84832899b698daa3821797