### PR TITLE
Ensure HTTPS startup and JWKS/rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ SOIPack, yazılım odaklı organizasyonların gereksinim, test, kod ve kalite ar
 - **@soipack/cli** – İzlenebilirlik işlemlerini otomatikleştiren komut satırı istemcisi.
 - **@soipack/server** – Express ve OpenAPI tabanlı REST servisleri.
 
+> Not: Sunucu yalnızca HTTPS dinleyicisiyle başlatılır; `SOIPACK_TLS_KEY_PATH` ve `SOIPACK_TLS_CERT_PATH` olmadan hizmet ayağa kalkmaz. Yönetici uç noktaları için istemci sertifikası doğrulaması isteğe bağlıdır (`SOIPACK_TLS_CLIENT_CA_PATH`). JWKS uç noktaları HTTPS ile çağrılmalı veya dosya sistemi üzerinden (`SOIPACK_AUTH_JWKS_PATH`) sağlanmalıdır. İstekler varsayılan olarak IP ve kiracı bazında sınırlandırılır (`SOIPACK_RATE_LIMIT_*`); JSON gövdeleri `SOIPACK_MAX_JSON_BODY_BYTES` eşiğini aşarsa `413` yanıtı döner.
+
 ## Başlarken
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,10 +17,18 @@ services:
       SOIPACK_STORAGE_DIR: /app/data
       SOIPACK_SIGNING_KEY_PATH: /run/secrets/soipack-signing.pem
       SOIPACK_LICENSE_PUBLIC_KEY_PATH: /run/secrets/soipack-license.pub
+      SOIPACK_TLS_KEY_PATH: /run/secrets/soipack-tls.key
+      SOIPACK_TLS_CERT_PATH: /run/secrets/soipack-tls.crt
+      SOIPACK_TLS_CLIENT_CA_PATH: ${SOIPACK_TLS_CLIENT_CA_PATH:-}
       SOIPACK_HEALTHCHECK_TOKEN: ${SOIPACK_HEALTHCHECK_TOKEN:?SOIPACK_HEALTHCHECK_TOKEN tanımlanmalıdır}
-      PORT: ${PORT:-3000}
+      SOIPACK_MAX_JSON_BODY_BYTES: ${SOIPACK_MAX_JSON_BODY_BYTES:-2097152}
+      SOIPACK_RATE_LIMIT_IP_WINDOW_MS: ${SOIPACK_RATE_LIMIT_IP_WINDOW_MS:-60000}
+      SOIPACK_RATE_LIMIT_IP_MAX_REQUESTS: ${SOIPACK_RATE_LIMIT_IP_MAX_REQUESTS:-300}
+      SOIPACK_RATE_LIMIT_TENANT_WINDOW_MS: ${SOIPACK_RATE_LIMIT_TENANT_WINDOW_MS:-60000}
+      SOIPACK_RATE_LIMIT_TENANT_MAX_REQUESTS: ${SOIPACK_RATE_LIMIT_TENANT_MAX_REQUESTS:-150}
+      PORT: ${PORT:-3443}
     ports:
-      - "3000:3000"
+      - "3443:3443"
     volumes:
       - ./data:/app/data
       # ./secrets klasöründe soipack-signing.pem ve soipack-license.pub dosyalarını bekler
@@ -32,11 +40,11 @@ services:
         - >-
           node -e "const token=process.env.SOIPACK_HEALTHCHECK_TOKEN;
           if(!token){process.exit(1);}
-          fetch('http://localhost:3000/health', {
+          fetch('https://localhost:3443/health', {
             headers: { Authorization: 'Bearer ' + token }
           }).then((res) => {
             if(!res.ok){process.exit(1);}
-          }).catch(() => process.exit(1));"
+          }).catch(() => process.exit(1));" 
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/soipack_security.md
+++ b/docs/soipack_security.md
@@ -24,3 +24,10 @@ SOIPack, gereksinim izlenebilirliği sonuçlarını paketlerken manifest imzası
 - **İz kayıtları**: `manifest.json` içindeki tarih damgası (`generatedAt`) sabitlenmiş demo zaman damgasıyla (`SOIPACK_DEMO_TIMESTAMP`) veya gerçek zamanlı saatle üretilir. Air-gap ortamında saat senkronizasyonu güvenilir NTP yerine kontrollü manuel prosedürlerle yapılmalıdır.【F:packages/cli/src/index.ts†L48-L115】
 
 Bu prosedürler, demo çıktılarındaki raporların ve manifestlerin denetlenebilirliğini korurken, üretim süreçlerinde uyarlanabilir güvenlik kontrolleri sağlar.
+
+## REST API Sertleştirmeleri
+
+- **HTTPS zorunluluğu**: @soipack/server yalnızca TLS sertifikası (`SOIPACK_TLS_CERT_PATH`) ve özel anahtarı (`SOIPACK_TLS_KEY_PATH`) sağlandığında başlatılır; düz HTTP dinleyicileri reddedilir. Yönetici uçları (`/v1/admin/cleanup` ve `/metrics`) için istemci sertifikası gereksinimi `SOIPACK_TLS_CLIENT_CA_PATH` ile etkinleştirilebilir ve yalnızca güvenilir istemci sertifikaları kabul edilir.
+- **JWKS güvenliği**: JSON Web Key Set uç noktaları yalnızca HTTPS üzerinden çözümlenir; air-gap ortamlarında JWKS içeriği dosya sistemi üzerinden (`SOIPACK_AUTH_JWKS_PATH`) sağlanabilir. Uzak JWKS çağrıları zaman aşımı, tekrar deneme ve önbellekleme limitleriyle sarılarak yanıt vermeyen sağlayıcılar `503 JWKS_UNAVAILABLE` hatasıyla raporlanır.
+- **İstek sınırlaması**: Uygulama katmanında kişi başı (`SOIPACK_RATE_LIMIT_IP_*`) ve kiracı başına (`SOIPACK_RATE_LIMIT_TENANT_*`) oran sınırlaması uygulanır. Limit aşılırsa `429` yanıtı döner ve `Retry-After` başlığı kullanılır.
+- **Gövde boyutu**: JSON istekleri `SOIPACK_MAX_JSON_BODY_BYTES` sınırı ile korunur; sınır aşılırsa API `413 PAYLOAD_TOO_LARGE` hatası üretir ve büyük gövde analizleri başlamadan engellenir.

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: SOIPack REST API
   version: 0.1.0
   description: |
-    SOIPack çalışma akışlarını HTTP üzerinden tetikleyen REST arayüzü.
+    SOIPack çalışma akışlarını HTTPS üzerinden tetikleyen REST arayüzü. Sunucu yalnızca TLS sertifikası ve anahtarı sağlandığında başlatılır; düz HTTP dinleyicileri desteklenmez. Uygulama IP ve kiracı bazında oran sınırlaması uygular ve JSON gövdeleri için maksimum boyut denetimi yapar.
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/packages/server/src/start.test.ts
+++ b/packages/server/src/start.test.ts
@@ -76,3 +76,125 @@ describe('resolveSigningKeyPath', () => {
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe('start', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  const prepareBaseEnv = async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'soipack-start-env-'));
+    const signingKeyPath = path.join(tmpDir, 'signing.pem');
+    const licenseKeyPath = path.join(tmpDir, 'license.pub');
+    const tlsKeyPath = path.join(tmpDir, 'server.key');
+    const tlsCertPath = path.join(tmpDir, 'server.crt');
+    const jwksPath = path.join(tmpDir, 'jwks.json');
+
+    await fs.promises.writeFile(signingKeyPath, 'signing-key');
+    await fs.promises.writeFile(licenseKeyPath, 'license-key');
+    await fs.promises.writeFile(tlsKeyPath, 'tls-key');
+    await fs.promises.writeFile(tlsCertPath, 'tls-cert');
+    await fs.promises.writeFile(
+      jwksPath,
+      JSON.stringify({ keys: [] }),
+      'utf8',
+    );
+
+    process.env.SOIPACK_AUTH_ISSUER = 'https://auth.example.com/';
+    process.env.SOIPACK_AUTH_AUDIENCE = 'soipack-api';
+    process.env.SOIPACK_AUTH_JWKS_PATH = jwksPath;
+    delete process.env.SOIPACK_AUTH_JWKS_URI;
+    process.env.SOIPACK_AUTH_TENANT_CLAIM = 'tenant';
+    process.env.SOIPACK_SIGNING_KEY_PATH = signingKeyPath;
+    process.env.SOIPACK_LICENSE_PUBLIC_KEY_PATH = licenseKeyPath;
+    process.env.SOIPACK_TLS_KEY_PATH = tlsKeyPath;
+    process.env.SOIPACK_TLS_CERT_PATH = tlsCertPath;
+    process.env.PORT = '3443';
+
+    return { tmpDir, tlsKeyPath, tlsCertPath };
+  };
+
+  it('exits when TLS key is missing', async () => {
+    const { tmpDir } = await prepareBaseEnv();
+    delete process.env.SOIPACK_TLS_KEY_PATH;
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code ?? 0}`);
+      }) as never);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { start } = await import('./start');
+    await expect(start()).rejects.toThrow('process.exit: 1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith('SOIPACK_TLS_KEY_PATH ortam değişkeni tanımlanmalıdır.');
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('starts HTTPS server with provided certificates', async () => {
+    const { tmpDir } = await prepareBaseEnv();
+    process.env.SOIPACK_TLS_CLIENT_CA_PATH = path.join(tmpDir, 'client-ca.pem');
+    await fs.promises.writeFile(process.env.SOIPACK_TLS_CLIENT_CA_PATH, 'client-ca');
+    process.env.SOIPACK_MAX_JSON_BODY_BYTES = '4096';
+    process.env.SOIPACK_RATE_LIMIT_IP_WINDOW_MS = '1000';
+    process.env.SOIPACK_RATE_LIMIT_IP_MAX_REQUESTS = '5';
+    process.env.SOIPACK_RATE_LIMIT_TENANT_WINDOW_MS = '1000';
+    process.env.SOIPACK_RATE_LIMIT_TENANT_MAX_REQUESTS = '3';
+
+    const mockApp = {};
+    const listenSpy = jest.fn<void, [number, (() => void)?]>((_port, callback) => {
+      callback?.();
+    });
+    const mockHttpsServer = { listen: listenSpy } as const;
+    const createServerMock = jest.fn(() => mockApp);
+    const createHttpsServerMock = jest.fn(() => mockHttpsServer);
+
+    jest.doMock('./index', () => ({
+      __esModule: true,
+      createServer: createServerMock,
+      createHttpsServer: createHttpsServerMock,
+      JwtAuthConfig: {} as never,
+      RateLimitConfig: {} as never,
+      RetentionConfig: {} as never,
+    }));
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { start } = await import('./start');
+    await start();
+
+    expect(createServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonBodyLimitBytes: 4096,
+        rateLimit: {
+          ip: { windowMs: 1000, max: 5 },
+          tenant: { windowMs: 1000, max: 3 },
+        },
+        requireAdminClientCertificate: true,
+      }),
+    );
+    expect(createHttpsServerMock).toHaveBeenCalledWith(
+      mockApp,
+      expect.objectContaining({
+        key: 'tls-key',
+        cert: 'tls-cert',
+        clientCa: 'client-ca',
+      }),
+    );
+    expect(listenSpy).toHaveBeenCalledWith(3443, expect.any(Function));
+    expect(logSpy).toHaveBeenCalledWith('SOIPack API HTTPS olarak 3443 portunda dinliyor.');
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- enforce HTTPS-only startup and add TLS/mTLS validation paths in server bootstrap
- harden JWT JWKS handling with filesystem support, HTTPS requirement, bounded fetches, and TLS error propagation
- introduce IP/tenant rate limiting, JSON body caps, and document the new deployment/security expectations

## Testing
- npm run test -- --config packages/server/jest.config.cjs --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cfc8cb6434832894089a63379837c3