### PR TITLE
chore: align ui imports for lint compliance

### DIFF
--- a/packages/ui/src/pages/DashboardPage.tsx
+++ b/packages/ui/src/pages/DashboardPage.tsx
@@ -1,0 +1,112 @@
+import { Alert, Badge, Card, EmptyState, PageHeader, Skeleton, Table } from '@bora/ui-kit';
+import type { AuditLogEntry } from '@soipack/ui-mocks';
+import { useEffect, useMemo, useState } from 'react';
+
+import { useAuditTrail } from '../providers/AuditTrailProvider';
+import { useT } from '../providers/I18nProvider';
+import { fetchDashboard, fetchLogs, type DashboardPayload } from '../services/mockService';
+
+export default function DashboardPage() {
+  const [dashboard, setDashboard] = useState<DashboardPayload | null>(null);
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { events } = useAuditTrail();
+  const t = useT();
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      const [dashboardData, logData] = await Promise.all([fetchDashboard(), fetchLogs()]);
+      setDashboard(dashboardData);
+      setLogs(logData);
+      setLoading(false);
+    }
+    void load();
+  }, []);
+
+  const recentActivity = useMemo(() => {
+    const synthetic = events.map((event) => ({
+      id: event.id,
+      correlationId: event.correlationId,
+      actor: event.actor,
+      role: event.role as AuditLogEntry['role'],
+      action: event.action,
+      severity: 'info' as AuditLogEntry['severity'],
+      createdAt: event.timestamp
+    }));
+    return [...synthetic, ...logs].slice(0, 6);
+  }, [events, logs]);
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t('dashboard.title')}
+        description={t('dashboard.description')}
+        breadcrumb={[{ label: t('dashboard.title') }]}
+      />
+
+      {loading && (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-36 w-full" />
+          ))}
+        </div>
+      )}
+
+      {!loading && dashboard && (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboard.metrics.map((metric) => (
+            <Card key={metric.id} title={metric.label} description={`${metric.value}${metric.unit ?? ''}`}>
+              <div className="flex items-end justify-between text-xs text-[color:var(--fg-muted)]">
+                <span>{metric.trend === 'up' ? '▲' : metric.trend === 'down' ? '▼' : '–'}</span>
+                <span>{metric.delta.toFixed(2)}</span>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {!loading && dashboard?.notices.length ? (
+        <div className="grid gap-3">
+          {dashboard.notices.map((notice) => (
+            <Alert
+              key={notice.id}
+              title={t('dashboard.notices')}
+              description={notice.message}
+              variant={notice.scope === 'internal' ? 'warning' : 'info'}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <section className="space-y-4">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">{t('dashboard.auditFeed')}</h2>
+          {dashboard?.health && (
+            <Badge variant="outline">
+              {t('dashboard.health')}: {t(`status.${dashboard.health.status.toLowerCase()}`)}
+            </Badge>
+          )}
+        </header>
+        {recentActivity.length === 0 ? (
+          <EmptyState title={t('logs.empty')} description="" />
+        ) : (
+          <Table
+            columns={[
+              { key: 'actor', title: 'Kullanıcı' },
+              { key: 'role', title: 'Rol' },
+              { key: 'action', title: 'Eylem' },
+              { key: 'createdAt', title: 'Zaman' }
+            ]}
+            rows={recentActivity.map((item) => ({
+              actor: item.actor,
+              role: item.role,
+              action: item.action,
+              createdAt: new Date(item.createdAt).toLocaleString()
+            }))}
+          />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/LogsPage.tsx
+++ b/packages/ui/src/pages/LogsPage.tsx
@@ -1,0 +1,125 @@
+import { Button, EmptyState, Input, PageHeader, Pagination, Select, Table, Toolbar } from '@bora/ui-kit';
+import type { AuditLogEntry } from '@soipack/ui-mocks';
+import { useEffect, useMemo, useState } from 'react';
+
+import { useAuditTrail } from '../providers/AuditTrailProvider';
+import { useT } from '../providers/I18nProvider';
+import { RoleGate } from '../providers/RbacProvider';
+import { fetchLogs } from '../services/mockService';
+
+const severityOptions = [
+  { value: 'all', label: 'Tümü' },
+  { value: 'info', label: 'Bilgi' },
+  { value: 'warning', label: 'Uyarı' },
+  { value: 'danger', label: 'Kritik' }
+];
+
+export default function LogsPage() {
+  const [logs, setLogs] = useState<AuditLogEntry[]>([]);
+  const [query, setQuery] = useState('');
+  const [severity, setSeverity] = useState('all');
+  const [page, setPage] = useState(1);
+  const pageSize = 8;
+  const t = useT();
+  const { logEvent } = useAuditTrail();
+
+  useEffect(() => {
+    void fetchLogs().then(setLogs);
+  }, []);
+
+  const filtered = useMemo(() => {
+    return logs
+      .filter((entry) =>
+        severity === 'all' ? true : entry.severity === severity
+      )
+      .filter((entry) =>
+        [entry.actor, entry.role, entry.action, entry.correlationId]
+          .join(' ')
+          .toLowerCase()
+          .includes(query.toLowerCase())
+      );
+  }, [logs, query, severity]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const visible = filtered.slice((page - 1) * pageSize, page * pageSize);
+
+  const handleExport = () => {
+    const header = 'actor,role,action,severity,createdAt,correlationId\n';
+    const rows = filtered
+      .map((entry) =>
+        [entry.actor, entry.role, entry.action, entry.severity, entry.createdAt, entry.correlationId]
+          .map((value) => `"${value.replace(/"/g, '""')}"`)
+          .join(',')
+      )
+      .join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'audit-logs.csv';
+    anchor.click();
+    URL.revokeObjectURL(url);
+    logEvent('Denetim kayıtları CSV dışa aktarıldı');
+  };
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t('logs.title')}
+        description={t('logs.description')}
+        breadcrumb={[{ label: t('dashboard.title'), href: '/' }, { label: t('logs.title') }]}
+        actions={
+          <RoleGate role={['admin', 'operator']}>
+            <Button onClick={handleExport} variant="secondary" size="sm">
+              {t('logs.exportCsv')}
+            </Button>
+          </RoleGate>
+        }
+      />
+
+      <Toolbar>
+        <Input
+          placeholder="Ara"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setPage(1);
+          }}
+          aria-label="Kayıt filtrele"
+        />
+        <Select
+          value={severity}
+          onValueChange={(value) => {
+            setSeverity(value);
+            setPage(1);
+          }}
+          options={severityOptions}
+        />
+        <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+      </Toolbar>
+
+      {visible.length === 0 ? (
+        <EmptyState title={t('logs.empty')} description="" />
+      ) : (
+        <Table
+          columns={[
+            { key: 'actor', title: 'Kullanıcı' },
+            { key: 'role', title: 'Rol' },
+            { key: 'action', title: 'Eylem' },
+            { key: 'severity', title: 'Seviye' },
+            { key: 'createdAt', title: 'Zaman' },
+            { key: 'correlationId', title: 'Correlation' }
+          ]}
+          rows={visible.map((entry) => ({
+            actor: entry.actor,
+            role: entry.role,
+            action: entry.action,
+            severity: entry.severity,
+            createdAt: new Date(entry.createdAt).toLocaleString(),
+            correlationId: entry.correlationId
+          }))}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/pages/SettingsPage.tsx
+++ b/packages/ui/src/pages/SettingsPage.tsx
@@ -1,0 +1,191 @@
+import {
+  Alert,
+  Button,
+  Card,
+  DateTimePicker,
+  Form,
+  FormField,
+  Input,
+  PageHeader,
+  Tabs,
+  Textarea,
+  useToast
+} from '@bora/ui-kit';
+import type { LicenseInfo } from '@soipack/ui-mocks';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { useAuditTrail } from '../providers/AuditTrailProvider';
+import { useT } from '../providers/I18nProvider';
+import { RoleGate } from '../providers/RbacProvider';
+import { fetchDashboard, fetchLicense } from '../services/mockService';
+
+interface SecurityFormValues {
+  incidentEmail: string;
+  retentionDays: number;
+  maintenance: { iso: string; tz: string };
+  maintenanceNotes: string;
+}
+
+export default function SettingsPage() {
+  const t = useT();
+  const { notify } = useToast();
+  const { logEvent } = useAuditTrail();
+  const [activeTab, setActiveTab] = useState('general');
+  const [license, setLicense] = useState<LicenseInfo | null>(null);
+  const [healthStatus, setHealthStatus] = useState('UP');
+  const environment = import.meta.env.VITE_ENVIRONMENT ?? 'DEV';
+
+  const form = useForm<SecurityFormValues>({
+    defaultValues: {
+      incidentEmail: 'soc@bora.def',
+      retentionDays: 90,
+      maintenance: { iso: new Date().toISOString(), tz: Intl.DateTimeFormat().resolvedOptions().timeZone },
+      maintenanceNotes: ''
+    }
+  });
+
+  useEffect(() => {
+    void fetchLicense().then(setLicense);
+    void fetchDashboard().then((data) => setHealthStatus(data.health.status));
+  }, []);
+
+  const handleSubmit = (values: SecurityFormValues) => {
+    logEvent('Güvenlik ayarları güncellendi');
+    notify({ title: t('notifications.success'), description: `${values.retentionDays} gün saklama` });
+  };
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t('settings.title')}
+        description={t('settings.description')}
+        breadcrumb={[{ label: t('dashboard.title'), href: '/' }, { label: t('settings.title') }]}
+      />
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <Tabs.List>
+          <Tabs.Trigger value="general">{t('settings.tab.general')}</Tabs.Trigger>
+          <Tabs.Trigger value="security">{t('settings.tab.security')}</Tabs.Trigger>
+          <Tabs.Trigger value="license">{t('settings.tab.license')}</Tabs.Trigger>
+          <Tabs.Trigger value="updates">{t('settings.tab.updates')}</Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="general">
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card title={t('settings.environment')} description={environment}>
+              <p className="text-sm text-[color:var(--fg-muted)]">{t('audit.banner')}</p>
+            </Card>
+            <Card title={t('dashboard.health')} description={t(`status.${healthStatus.toLowerCase()}`)} />
+          </div>
+        </Tabs.Content>
+
+        <Tabs.Content value="security">
+          <RoleGate role={['admin', 'operator']}>
+            <Form form={form} onSubmit={handleSubmit}>
+              <FormField
+                control={form.control}
+                name="incidentEmail"
+                label="Olay e-posta"
+                input={({ name, onChange, value, id, error }) => (
+                  <Input
+                    id={id}
+                    name={name}
+                    value={value as string}
+                    onChange={onChange}
+                    type="email"
+                    required
+                    invalid={error}
+                  />
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="retentionDays"
+                label="Saklama (gün)"
+                input={({ name, onChange, value, id, error }) => (
+                  <Input
+                    id={id}
+                    name={name}
+                    value={String(value ?? '')}
+                    onChange={(event) => onChange(Number(event.target.value))}
+                    type="number"
+                    min={30}
+                    max={365}
+                    invalid={error}
+                  />
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="maintenance"
+                label="Bakım penceresi"
+                input={({ value, onChange }) => (
+                  <DateTimePicker value={value as SecurityFormValues['maintenance']} onChange={onChange} />
+                )}
+              />
+              <RoleGate role="admin">
+                <FormField
+                  control={form.control}
+                  name="maintenanceNotes"
+                  label="Notlar"
+                  input={({ name, value, onChange, id, error }) => (
+                    <Textarea
+                      id={id}
+                      name={name}
+                      value={value as string}
+                      onChange={onChange}
+                      rows={3}
+                      placeholder="Planlanan bakım adımları"
+                      invalid={error}
+                    />
+                  )}
+                />
+              </RoleGate>
+              <div className="flex justify-end">
+                <Button type="submit" variant="primary">
+                  {t('wizard.sign.cta')}
+                </Button>
+              </div>
+            </Form>
+          </RoleGate>
+        </Tabs.Content>
+
+        <Tabs.Content value="license">
+          {license ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              <Card title={t('settings.licenseSerial')} description={license.serial} />
+              <Card title={t('settings.licenseExpiry')} description={new Date(license.expiresAt).toLocaleDateString()} />
+              <Card title={t('settings.features')}>
+                <ul className="space-y-2 text-sm text-[color:var(--fg-default)]">
+                  {license.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+              </Card>
+            </div>
+          ) : (
+            <Alert title="Lisans" description="Veri yükleniyor" variant="info" />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="updates">
+          <Card title={t('settings.updatePolicy')}>
+            <Textarea rows={4} defaultValue="Yama penceresi her Çarşamba 02:00-04:00 arası uygulanır." />
+            <div className="mt-4 flex justify-end">
+              <RoleGate role="admin">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => logEvent('Güncelleme politikası güncellendi')}
+                >
+                  {t('wizard.deploy.cta')}
+                </Button>
+              </RoleGate>
+            </div>
+          </Card>
+        </Tabs.Content>
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/ui/src/providers/I18nProvider.tsx
+++ b/packages/ui/src/providers/I18nProvider.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
+
+import { translate, type Locale } from '../microcopy';
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (next: Locale) => void;
+  t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>('tr');
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: (key) => translate(locale, key)
+    }),
+    [locale]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used inside I18nProvider');
+  }
+  return context;
+}
+
+export function useT() {
+  return useI18n().t;
+}


### PR DESCRIPTION
## Summary
- reorder external and internal imports in the new UI pages so eslint import/order rules pass
- clean up the I18n provider to remove the unused microcopy symbol

## Testing
- npm run lint --workspace @soipack/ui
- npm run typecheck --workspace @soipack/ui
- npm run test --workspace @soipack/ui *(fails: vitest picks up Playwright suite tests/smoke.spec.ts)*
- npm run e2e --workspace @soipack/ui *(fails: Playwright config references __dirname in ESM module)*

------
https://chatgpt.com/codex/tasks/task_b_68d042d0c9c88328b81c24acaa4a25c1