### PR TITLE
feat: surface MC/DC coverage and compliance quality findings

### DIFF
--- a/docs/soipack_user_guide.md
+++ b/docs/soipack_user_guide.md
@@ -162,6 +162,10 @@ Sunucu yanıtları her durumda `error.code`, `error.message` ve (varsa) `error.d
 ### Raporları inceleme
 Raporlar `dist/reports/` altında toplanır. Uyum (`compliance.html`/`compliance.json`), izlenebilirlik (`trace.html`) ve boşluk (`gaps.html`) çıktıları tarayıcıda açılarak inceleme yapılabilir; aynı klasörde `analysis.json`, `snapshot.json` ve `traces.json` çalışma zamanı verileri yer alır. `plans/` alt dizini ise PSAC, SDP, SVP, SCMP ve SQAP belgelerinin HTML/DOCX sürümlerini barındırır; Playwright Chromium mevcutsa aynı adlarla PDF kopyaları da oluşturulur. Pipeline paketleri bu dosyaları ve manifesti `release/soi-pack-*.zip` arşivine dahil eder.【F:docs/demo_script.md†L18-L31】
 
+Uyum matrisi artık yapısal kapsam metriklerini Satır/Dallanma/Fonksiyon değerlerinin yanında MC/DC yüzdeleriyle birlikte gösterir. Gereksinimlere ait kod izleri bu dört metriği toplu olarak hesaplar; `MC/DC: %` etiketi tüm raporlarda otomatik görünür. Aynı matriste yeni “Kalite Bulguları” bloğu yer alır. Bu bölüm, doğrulandı olarak işaretlenmiş ama teste izlenmemiş gereksinimler, başarısız doğrulama testleri veya eksik kapsam gibi çelişkileri listeler. Kritik (hata) ve uyarı seviyeleri farklı rozet renkleriyle vurgulanır; her bulgu ilgili gereksinim, etkilediği test kimlikleri ve önerilen düzeltici aksiyon ile birlikte sunulur.
+
+`analysis.json` çıktısı bu bulguları programatik olarak tüketebilmek için `qualityFindings` dizisini içerir. Dizideki her öğe; `severity` (error/warn/info), `category` (trace/tests/coverage), `message`, `requirementId`, `relatedTests` ve `recommendation` alanlarını taşır. CI/CD iş akışlarında bu alanları kullanarak örneğin doğrulandı durumda olup teste bağlanmamış gereksinimler için pipeline'ı başarısız sayabilir veya otomatik JIRA görevleri açabilirsiniz. Bir bulgu raporda belirdiyse, ilgili gereksinim durumunu gözden geçirmek, eksik test izlerini eklemek veya kapsam raporlarını güncellemek önerilir.
+
 ### Web arayüzü ile pipeline takibi
 
 SOIPack, REST API üzerinden yürütülen işleri gözlemlemek için React tabanlı bir arayüz sunar. Arayüzü başlatmak için repoda aşağıdaki komutu uygulayın:

--- a/packages/adapters/fixtures/ldra/tbvision.json
+++ b/packages/adapters/fixtures/ldra/tbvision.json
@@ -24,7 +24,9 @@
     "files": [
       {
         "path": "src/foo.c",
-        "stmt": { "covered": 50, "total": 60 }
+        "stmt": { "covered": 50, "total": 60 },
+        "dec": { "covered": 30, "total": 40 },
+        "mcdc": { "covered": 28, "total": 40 }
       }
     ]
   }

--- a/packages/adapters/src/cobertura.ts
+++ b/packages/adapters/src/cobertura.ts
@@ -202,13 +202,19 @@ export const importCobertura = async (filePath: string): Promise<ParseResult<Cov
     if (file.functions) {
       acc.functions = addMetric(acc.functions, { ...file.functions });
     }
+    if (file.mcdc) {
+      acc.mcdc = addMetric(acc.mcdc, { ...file.mcdc });
+    }
     return acc;
-  }, { statements: { covered: 0, total: 0, percentage: 0 } } as CoverageReport['totals']);
+  }, {
+    statements: { covered: 0, total: 0, percentage: 0 },
+  } as CoverageReport['totals']);
 
   const finalizedTotals: CoverageReport['totals'] = {
     statements: finalizeMetric(totals.statements)!,
     branches: finalizeMetric(totals.branches),
     functions: finalizeMetric(totals.functions),
+    mcdc: finalizeMetric(totals.mcdc),
   };
   const testMapEntries = Array.from(testFiles.entries()).map(([test, filesForTest]) => [test, Array.from(filesForTest)]);
   const testMap = testMapEntries.length > 0 ? Object.fromEntries(testMapEntries) : undefined;

--- a/packages/adapters/src/lcov.ts
+++ b/packages/adapters/src/lcov.ts
@@ -13,6 +13,7 @@ interface FileAccumulator {
   statements: MetricAccumulator;
   branches: MetricAccumulator;
   functions: MetricAccumulator;
+  mcdc: MetricAccumulator;
 }
 
 const createAccumulator = (file: string): FileAccumulator => ({
@@ -20,6 +21,7 @@ const createAccumulator = (file: string): FileAccumulator => ({
   statements: { covered: 0, total: 0 },
   branches: { covered: 0, total: 0 },
   functions: { covered: 0, total: 0 },
+  mcdc: { covered: 0, total: 0 },
 });
 
 const toCoverageMetric = ({ covered, total }: MetricAccumulator): CoverageMetric => ({
@@ -51,13 +53,20 @@ const finalizeFile = (file: FileAccumulator): FileCoverageSummary => ({
   statements: toCoverageMetric(file.statements),
   branches: file.branches.total > 0 ? toCoverageMetric(file.branches) : undefined,
   functions: file.functions.total > 0 ? toCoverageMetric(file.functions) : undefined,
+  mcdc: file.mcdc.total > 0 ? toCoverageMetric(file.mcdc) : undefined,
 });
 
 const accumulateTotals = (files: FileCoverageSummary[]): CoverageReport['totals'] => {
-  const totals: { statements: MetricAccumulator; branches: MetricAccumulator; functions: MetricAccumulator } = {
+  const totals: {
+    statements: MetricAccumulator;
+    branches: MetricAccumulator;
+    functions: MetricAccumulator;
+    mcdc: MetricAccumulator;
+  } = {
     statements: { covered: 0, total: 0 },
     branches: { covered: 0, total: 0 },
     functions: { covered: 0, total: 0 },
+    mcdc: { covered: 0, total: 0 },
   };
 
   files.forEach((file) => {
@@ -73,12 +82,18 @@ const accumulateTotals = (files: FileCoverageSummary[]): CoverageReport['totals'
       totals.functions.covered += file.functions.covered;
       totals.functions.total += file.functions.total;
     }
+
+    if (file.mcdc) {
+      totals.mcdc.covered += file.mcdc.covered;
+      totals.mcdc.total += file.mcdc.total;
+    }
   });
 
   return {
     statements: toCoverageMetric(totals.statements),
     branches: totals.branches.total > 0 ? toCoverageMetric(totals.branches) : undefined,
     functions: totals.functions.total > 0 ? toCoverageMetric(totals.functions) : undefined,
+    mcdc: totals.mcdc.total > 0 ? toCoverageMetric(totals.mcdc) : undefined,
   };
 };
 

--- a/packages/adapters/src/staticTools.test.ts
+++ b/packages/adapters/src/staticTools.test.ts
@@ -52,6 +52,8 @@ describe('Static analysis adapters', () => {
     expect(data.coverage?.files[0]).toEqual({
       path: 'src/foo.c',
       stmt: { covered: 50, total: 60 },
+      dec: { covered: 30, total: 40 },
+      mcdc: { covered: 28, total: 40 },
     });
     expect(data.coverage?.objectiveLinks).toEqual(['A-5-08']);
   });

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -79,6 +79,7 @@ export interface FileCoverageSummary {
   statements: CoverageMetric;
   branches?: CoverageMetric;
   functions?: CoverageMetric;
+  mcdc?: CoverageMetric;
 }
 
 export interface CoverageReport {
@@ -86,6 +87,7 @@ export interface CoverageReport {
     statements: CoverageMetric;
     branches?: CoverageMetric;
     functions?: CoverageMetric;
+    mcdc?: CoverageMetric;
   };
   files: FileCoverageSummary[];
   testMap?: Record<string, string[]>;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1668,6 +1668,7 @@ export const runAnalyze = async (options: AnalyzeOptions): Promise<AnalyzeResult
     git: workspace.git,
     inputs: workspace.metadata.inputs,
     warnings: workspace.metadata.warnings,
+    qualityFindings: snapshot.qualityFindings,
   });
 
   const hasMissingEvidence = snapshot.objectives.some(
@@ -1810,6 +1811,7 @@ export const runReport = async (options: ReportOptions): Promise<ReportResult> =
     git?: BuildInfo | null;
     inputs: ImportPaths;
     warnings: string[];
+    qualityFindings: ComplianceSnapshot['qualityFindings'];
   }>(analysisPath);
   const snapshot = await readJsonFile<ComplianceSnapshot>(snapshotPath);
   const traces = await readJsonFile<RequirementTrace[]>(tracePath);

--- a/packages/engine/src/quality.ts
+++ b/packages/engine/src/quality.ts
@@ -1,0 +1,140 @@
+import type { Requirement } from '@soipack/core';
+
+import type { RequirementCoverageStatus, RequirementTrace } from './index';
+
+export type QualityFindingSeverity = 'info' | 'warn' | 'error';
+export type QualityFindingCategory = 'trace' | 'tests' | 'coverage';
+
+export interface QualityFinding {
+  id: string;
+  severity: QualityFindingSeverity;
+  category: QualityFindingCategory;
+  message: string;
+  requirementId?: string;
+  recommendation?: string;
+  relatedTests?: string[];
+}
+
+interface RequirementQualityContext {
+  trace: RequirementTrace;
+  coverage?: RequirementCoverageStatus;
+}
+
+const failingTests = (trace: RequirementTrace): RequirementTrace['tests'] =>
+  trace.tests.filter((test) => test.status === 'failed');
+
+const skippedTests = (trace: RequirementTrace): RequirementTrace['tests'] =>
+  trace.tests.filter((test) => test.status === 'skipped');
+
+const buildFindingId = (requirement: Requirement, suffix: string): string =>
+  `${requirement.id}-${suffix}`;
+
+const ensureUnique = (findings: QualityFinding[]): QualityFinding[] => {
+  const seen = new Set<string>();
+  const result: QualityFinding[] = [];
+  findings.forEach((finding) => {
+    if (seen.has(finding.id)) {
+      return;
+    }
+    seen.add(finding.id);
+    result.push(finding);
+  });
+  return result;
+};
+
+const evaluateRequirement = ({ trace, coverage }: RequirementQualityContext): QualityFinding[] => {
+  const requirement = trace.requirement;
+  const findings: QualityFinding[] = [];
+  const linkedTests = trace.tests;
+  const coverageStatus = coverage?.status;
+
+  if (requirement.status === 'verified' && linkedTests.length === 0) {
+    findings.push({
+      id: buildFindingId(requirement, 'verified-no-tests'),
+      severity: 'error',
+      category: 'trace',
+      requirementId: requirement.id,
+      message: `${requirement.id} doğrulandı olarak işaretli ancak ilişkilendirilmiş test bulunamadı.`,
+      recommendation:
+        'Gereksinim ile ilişkili doğrulama testlerini izleyin veya gereksinim durumunu güncel hale getirin.',
+    });
+  }
+
+  if (requirement.status === 'verified') {
+    const failed = failingTests(trace);
+    if (failed.length > 0) {
+      findings.push({
+        id: buildFindingId(requirement, 'verified-failing-tests'),
+        severity: 'error',
+        category: 'tests',
+        requirementId: requirement.id,
+        message: `${requirement.id} doğrulandı olarak işaretli ancak başarısız testler mevcut.`,
+        recommendation: 'Başarısız testleri analiz edin ve gereksinim doğrulama kanıtını güncelleyin.',
+        relatedTests: failed.map((test) => test.testId),
+      });
+    }
+
+    const skipped = skippedTests(trace);
+    if (skipped.length > 0) {
+      findings.push({
+        id: buildFindingId(requirement, 'verified-skipped-tests'),
+        severity: 'warn',
+        category: 'tests',
+        requirementId: requirement.id,
+        message: `${requirement.id} doğrulandı olarak işaretli ancak atlanan testler var.`,
+        recommendation: 'Atlanan testlerin tekrar koşulmasını planlayın veya gereksinim durumunu yeniden değerlendirin.',
+        relatedTests: skipped.map((test) => test.testId),
+      });
+    }
+  }
+
+  if (requirement.status === 'implemented' && linkedTests.length === 0) {
+    findings.push({
+      id: buildFindingId(requirement, 'implemented-no-tests'),
+      severity: 'warn',
+      category: 'trace',
+      requirementId: requirement.id,
+      message: `${requirement.id} uygulandı olarak işaretli ancak test bağlantısı yok.`,
+      recommendation: 'Gereksinimi doğrulayan testleri planlayın veya durumu güncelleyin.',
+    });
+  }
+
+  if ((requirement.status === 'implemented' || requirement.status === 'verified') && coverageStatus) {
+    if (coverageStatus === 'missing') {
+      findings.push({
+        id: buildFindingId(requirement, 'coverage-missing'),
+        severity: requirement.status === 'verified' ? 'error' : 'warn',
+        category: 'coverage',
+        requirementId: requirement.id,
+        message: `${requirement.id} için kapsama verisi bulunamadı.`,
+        recommendation: 'Kod izlerini ve kapsam raporlarını gereksinime bağlayın veya durumu yeniden değerlendirin.',
+      });
+    } else if (coverageStatus === 'partial' && requirement.status === 'verified') {
+      findings.push({
+        id: buildFindingId(requirement, 'coverage-partial'),
+        severity: 'warn',
+        category: 'coverage',
+        requirementId: requirement.id,
+        message: `${requirement.id} doğrulandı olarak işaretli ancak kapsam verisi kısmi.`,
+        recommendation: 'Eksik kapsamı tamamlayın veya gereksinim durumunu güncelleyin.',
+      });
+    }
+  }
+
+  return findings;
+};
+
+export const evaluateQualityFindings = (
+  traces: RequirementTrace[],
+  coverage: RequirementCoverageStatus[],
+): QualityFinding[] => {
+  const coverageByRequirement = new Map<string, RequirementCoverageStatus>(
+    coverage.map((entry) => [entry.requirement.id, entry]),
+  );
+
+  const findings = traces.flatMap((trace) =>
+    evaluateRequirement({ trace, coverage: coverageByRequirement.get(trace.requirement.id) }),
+  );
+
+  return ensureUnique(findings);
+};

--- a/packages/report/src/__fixtures__/goldens/compliance-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/compliance-matrix.html
@@ -303,6 +303,14 @@
             <span>Eksik/Kısmi Kapsam</span>
             <strong>2/1</strong>
           </div>
+          <div class="summary-card">
+            <span>Kalite Bulguları</span>
+            <strong>2</strong>
+          </div>
+          <div class="summary-card">
+            <span>Kritik/Uyarı</span>
+            <strong>1/1</strong>
+          </div>
       </div>
     </header>
     <main>
@@ -433,6 +441,31 @@ A-6 • Değişiklik Kontrolü                </div>
     </table>
   </section>
     <section class="section">
+      <h2>Kalite Bulguları</h2>
+      <p class="section-lead">
+        Gereksinim durumu, test sonuçları ve kapsam verileri arasındaki tutarsızlıkları vurgular. Bulgular düzeltici eylem gerektiren alanları önceliklendirmenizi sağlar.
+      </p>
+      <ul class="list">
+          <li>
+            <div>
+              <span class="badge status-missing">Kritik</span>
+              <span class="cell-title">REQ-AUTH-2 doğrulandı olarak işaretli ancak başarısız testler mevcut.</span>
+            </div>
+              <div class="muted">Gereksinim: REQ-AUTH-2</div>
+              <div class="muted">İlgili Testler: TC-LOGIN-2</div>
+              <div class="cell-description">Başarısız testleri analiz edin ve gereksinim doğrulama kanıtını güncelleyin.</div>
+          </li>
+          <li>
+            <div>
+              <span class="badge status-partial">Uyarı</span>
+              <span class="cell-title">REQ-AUTH-2 doğrulandı olarak işaretli ancak kapsam verisi kısmi.</span>
+            </div>
+              <div class="muted">Gereksinim: REQ-AUTH-2</div>
+              <div class="cell-description">Eksik kapsamı tamamlayın veya gereksinim durumunu güncelleyin.</div>
+          </li>
+      </ul>
+    </section>
+    <section class="section">
       <h2>Gereksinim Kapsamı</h2>
       <p class="section-lead">
         Testler ve kod izleri ile ilişkilendirilen gereksinimlerin kapsam durumunu gösterir. Yetersiz kapsama sahip alanları hızla tespit etmeyi sağlar.
@@ -453,7 +486,7 @@ A-6 • Değişiklik Kontrolü                </div>
               </td>
               <td>
                 <span class="badge status-partial">Kısmen Kaplandı</span>
-                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67% | MC/DC: 62.5%</div>
               </td>
               <td>
                   <ul class="list">
@@ -469,7 +502,7 @@ A-6 • Değişiklik Kontrolü                </div>
               </td>
               <td>
                 <span class="badge status-partial">Kısmen Kaplandı</span>
-                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                  <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67% | MC/DC: 62.5%</div>
               </td>
               <td>
                   <ul class="list">

--- a/packages/report/src/__fixtures__/goldens/compliance-matrix.json
+++ b/packages/report/src/__fixtures__/goldens/compliance-matrix.json
@@ -5,8 +5,8 @@
   "stats": {
     "objectives": {
       "total": 5,
-      "covered": 2,
-      "partial": 2,
+      "covered": 1,
+      "partial": 3,
       "missing": 1
     },
     "requirements": {
@@ -77,7 +77,7 @@
     },
     {
       "id": "A-5-08",
-      "status": "covered",
+      "status": "partial",
       "table": "A-5",
       "name": "Yapısal Kapsam—Statement",
       "desc": "Kod satır kapsamı ölçüldü ve açıklandı.",
@@ -85,7 +85,9 @@
         "Satır Kapsamı",
         "Analiz"
       ],
-      "missingArtifacts": [],
+      "missingArtifacts": [
+        "Satır Kapsamı"
+      ],
       "evidenceRefs": [
         "coverage_stmt:reports/coverage-summary.json",
         "analysis:reports/safety-analysis.pdf"
@@ -125,6 +127,11 @@
           "covered": 12,
           "total": 18,
           "percentage": 66.67
+        },
+        "mcdc": {
+          "covered": 20,
+          "total": 32,
+          "percentage": 62.5
         }
       },
       "codePaths": [
@@ -151,6 +158,11 @@
           "covered": 12,
           "total": 18,
           "percentage": 66.67
+        },
+        "mcdc": {
+          "covered": 20,
+          "total": 32,
+          "percentage": 62.5
         }
       },
       "codePaths": [
@@ -164,6 +176,27 @@
       "status": "missing",
       "coverage": {},
       "codePaths": []
+    }
+  ],
+  "qualityFindings": [
+    {
+      "id": "REQ-AUTH-2-verified-failing-tests",
+      "severity": "error",
+      "category": "tests",
+      "message": "REQ-AUTH-2 doğrulandı olarak işaretli ancak başarısız testler mevcut.",
+      "requirementId": "REQ-AUTH-2",
+      "recommendation": "Başarısız testleri analiz edin ve gereksinim doğrulama kanıtını güncelleyin.",
+      "relatedTests": [
+        "TC-LOGIN-2"
+      ]
+    },
+    {
+      "id": "REQ-AUTH-2-coverage-partial",
+      "severity": "warn",
+      "category": "coverage",
+      "message": "REQ-AUTH-2 doğrulandı olarak işaretli ancak kapsam verisi kısmi.",
+      "requirementId": "REQ-AUTH-2",
+      "recommendation": "Eksik kapsamı tamamlayın veya gereksinim durumunu güncelleyin."
     }
   ],
   "git": {

--- a/packages/report/src/__fixtures__/goldens/trace-matrix.html
+++ b/packages/report/src/__fixtures__/goldens/trace-matrix.html
@@ -315,7 +315,7 @@
                 <div class="muted">Durum: approved</div>
                 <div>
                   <span class="badge status-partial">Kısmen Kaplandı</span>
-                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67% | MC/DC: 62.5%</div>
                 </div>
             </td>
             <td>
@@ -336,11 +336,11 @@
                 <ul class="list">
                     <li>
                       <code class="code-pill">src/auth/login.ts</code>
-                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80%</div>
+                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80% | MC/DC: 75%</div>
                     </li>
                     <li>
                       <code class="code-pill">src/security/audit.ts</code>
-                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50%</div>
+                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50% | MC/DC: 50%</div>
                     </li>
                 </ul>
             </td>
@@ -349,10 +349,10 @@
             <td>
               <div class="cell-title">REQ-AUTH-2</div>
               <div class="cell-description">Başarısız girişler kaydedilmeli</div>
-                <div class="muted">Durum: implemented</div>
+                <div class="muted">Durum: verified</div>
                 <div>
                   <span class="badge status-partial">Kısmen Kaplandı</span>
-                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67%</div>
+                    <div class="muted">Satır: 68.75% | Dallanma: 64.29% | Fonksiyon: 66.67% | MC/DC: 62.5%</div>
                 </div>
             </td>
             <td>
@@ -373,11 +373,11 @@
                 <ul class="list">
                     <li>
                       <code class="code-pill">src/auth/login.ts</code>
-                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80%</div>
+                        <div class="muted">Satır: 87.5% | Dallanma: 75% | Fonksiyon: 80% | MC/DC: 75%</div>
                     </li>
                     <li>
                       <code class="code-pill">src/security/audit.ts</code>
-                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50%</div>
+                        <div class="muted">Satır: 50% | Dallanma: 50% | Fonksiyon: 50% | MC/DC: 50%</div>
                     </li>
                 </ul>
             </td>

--- a/packages/report/src/__fixtures__/snapshot.ts
+++ b/packages/report/src/__fixtures__/snapshot.ts
@@ -50,6 +50,7 @@ const coverageFixture = (): CoverageReport => ({
     statements: { covered: 55, total: 80, percentage: 68.75 },
     branches: { covered: 22, total: 40, percentage: 55 },
     functions: { covered: 18, total: 24, percentage: 75 },
+    mcdc: { covered: 20, total: 32, percentage: 62.5 },
   },
   files: [
     {
@@ -57,12 +58,14 @@ const coverageFixture = (): CoverageReport => ({
       statements: { covered: 28, total: 32, percentage: 87.5 },
       branches: { covered: 12, total: 16, percentage: 75 },
       functions: { covered: 8, total: 10, percentage: 80 },
+      mcdc: { covered: 12, total: 16, percentage: 75 },
     },
     {
       file: 'src/security/audit.ts',
       statements: { covered: 16, total: 32, percentage: 50 },
       branches: { covered: 6, total: 12, percentage: 50 },
       functions: { covered: 4, total: 8, percentage: 50 },
+      mcdc: { covered: 8, total: 16, percentage: 50 },
     },
   ],
 });
@@ -74,6 +77,7 @@ const structuralCoverageFixture = (): CoverageSummary => ({
       path: 'src/auth/login.ts',
       stmt: { covered: 55, total: 80 },
       dec: { covered: 22, total: 40 },
+      mcdc: { covered: 20, total: 32 },
     },
   ],
   objectiveLinks: ['A-5-08'],
@@ -168,7 +172,7 @@ const requirementFixture = () => [
     tags: ['security', 'auth'],
   }),
   createRequirement('REQ-AUTH-2', 'Başarısız girişler kaydedilmeli', {
-    status: 'implemented',
+    status: 'verified',
     tags: ['audit'],
   }),
   createRequirement('REQ-AUTH-3', 'Giriş ihlallerinde uyarı gönderilmeli', {
@@ -184,6 +188,9 @@ const evidenceFixture = (): ImportBundle['evidenceIndex'] => ({
   trace: [buildEvidence('trace', 'artifacts/trace-map.csv', 'İzlenebilirlik matrisi')],
   coverage_stmt: [
     buildEvidence('coverage_stmt', 'reports/coverage-summary.json', 'Satır kapsamı özeti'),
+  ],
+  coverage_mcdc: [
+    buildEvidence('coverage_mcdc', 'reports/vectorcast.json', 'MC/DC kapsam raporu'),
   ],
 });
 

--- a/packages/report/src/index.test.ts
+++ b/packages/report/src/index.test.ts
@@ -49,12 +49,14 @@ describe('@soipack/report', () => {
     expect(result.json.requirementCoverage).toHaveLength(
       fixture.snapshot.requirementCoverage.length,
     );
+    expect(result.json.qualityFindings.length).toBeGreaterThan(0);
     expect(result.json.git).toEqual(gitFixture);
 
     const goldenHtml = readFileSync(path.join(goldenDir, 'compliance-matrix.html'), 'utf-8');
     expect(hashHtml(result.html)).toBe(hashHtml(goldenHtml));
     expect(result.html).toContain('Kanıt Manifest ID');
     expect(result.html).toContain('Commit:');
+    expect(result.html).toContain('Kalite Bulguları');
   });
 
   it('renders trace matrix with trace information', () => {


### PR DESCRIPTION
## Summary
- extend coverage report types and adapters so LDRA/LCOV/Cobertura imports preserve MC/DC metrics alongside existing data
- add a reusable quality evaluation module to the engine, surface its findings in CLI analysis output, and render a "Kalite Bulguları" section in compliance reports
- update fixtures, goldens, and documentation to demonstrate MC/DC propagation and describe remediation expectations for quality findings

## Testing
- `npx jest --runTestsByPath packages/adapters/src/staticTools.test.ts packages/engine/src/index.test.ts packages/report/src/index.test.ts packages/cli/src/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68d10e0214f0832884ee058d4309e2e2