### PR TITLE
Fix compliance hash canonicalization and CLI coverage summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,28 @@ CLI paketini derleyip minimal örnek verilerle uçtan uca bir paket oluşturmak 
    }
    ```
 
+6. Aynı süreci tek komutta çalıştırmak için `ingest` komutunu kullanabilirsiniz:
+
+   ```bash
+   node packages/cli/dist/index.js --license data/licenses/demo-license.key ingest \
+     --input examples/minimal \
+     --output dist
+   ```
+
+   Komut, belirtilen girdi dizinindeki artefaktları içe aktarır, uyum analizi gerçekleştirir ve raporları `dist/reports` altına kaydeder. Çıktı özetinde toplam/karşılanan hedef sayıları ve kapsam yüzdeleri görüntülenir.
+
+7. Manifest ve zip paketini tek adımda oluşturmak için `package` komutunu çalıştırın:
+
+   ```bash
+   node packages/cli/dist/index.js --license data/licenses/demo-license.key package \
+     --input examples/minimal \
+     --output dist \
+     --signing-key path/to/signing-key.pem \
+     --package-name soi-pack.zip
+   ```
+
+   Bu komut, `ingest` adımlarını tekrar ederek raporları günceller, `manifest.json` ve `manifest.sig` dosyalarını üretir ve tüm kanıtları `dist/soi-pack.zip` arşivine sıkıştırır. Manifestte listelenen dosya karmaları ve imza, `verify` komutu ile doğrulanabilir.
+
    JSON anahtarları plan kimliklerini (`psac`, `sdp`, `svp`, `scmp`, `sqap`) temsil eder; her plan içinde `overview`, `sections` (plan şablonundaki bölüm kimlikleri) ve isteğe bağlı `additionalNotes` alanları HTML içeriği kabul eder.
 
 6. Dağıtım paketini hazırlayın:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,387 @@
+openapi: 3.1.0
+info:
+  title: SOIPack API
+  version: 0.1.0
+  description: >-
+    Uyum kanıtlarını toplamak ve rapor akışlarını doğrulamak için kullanılan SOIPack
+    REST API'sinin çekirdek uç noktaları. Tüm kimlik doğrulamalı istekler JWT
+    bearer belirteci gerektirir ve hız limitleri aşılırsa `429` yanıtı döner.
+servers:
+  - url: https://api.example.com
+    description: Örnek üretim sunucusu
+paths:
+  /health:
+    get:
+      summary: Sunucu sağlık durumu
+      description: Kimliği doğrulanmamış sağlık kontrolü uç noktası.
+      responses:
+        '200':
+          description: Sunucu çalışıyor.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /evidence:
+    get:
+      summary: Yüklenen kanıtları listele
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Kanıt kayıtlarının listesi.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EvidenceItem'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+  /evidence/upload:
+    post:
+      summary: Yeni kanıt yükle
+      description: >-
+        Base64 kodlu içeriği SHA-256 özetiyle birlikte yükleyerek yeni bir kanıt
+        kaydı oluşturur. `metadata.sha256` alanı, sunucunun hesapladığı özetle
+        eşleşmelidir.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvidenceUploadRequest'
+      responses:
+        '201':
+          description: Kanıt başarıyla yüklendi.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceItem'
+        '400':
+          description: Geçersiz gövde, hash uyuşmazlığı veya boyut tutarsızlığı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+  /evidence/{id}:
+    get:
+      summary: Kanıt ayrıntılarını getir
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Kanıt kimliği.
+      responses:
+        '200':
+          description: Kanıt kaydı döndürülür.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvidenceItemWithContent'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Kanıt bulunamadı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+  /compliance:
+    get:
+      summary: Uyum kayıtlarını listele
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Kaydedilmiş uyum kayıtlarının listesi.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ComplianceRecord'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+    post:
+      summary: Yeni uyum kaydı oluştur
+      description: >-
+        Uyum matrisi, kapsam özetleri ve SHA-256 doğrulamasıyla birlikte yeni bir
+        uyum kaydı oluşturur. Gereksinimlerde referans verilen kanıt kimliklerinin
+        mevcut olması gerekir.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComplianceSubmission'
+      responses:
+        '201':
+          description: Uyum kaydı oluşturuldu.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceRecord'
+        '400':
+          description: Uyum verisi doğrulamayı geçemedi.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+  /compliance/{id}:
+    get:
+      summary: Uyum kaydını getir
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Uyum kaydı kimliği.
+      responses:
+        '200':
+          description: Uyum kaydının ayrıntıları.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceRecord'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Kayıt bulunamadı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    UnauthorizedError:
+      description: JWT kimlik doğrulaması başarısız oldu.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    RateLimitedError:
+      description: İstek hızı sınırı aşıldı.
+      headers:
+        Retry-After:
+          description: Saniye cinsinden önerilen bekleme süresi.
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+    EvidenceMetadata:
+      type: object
+      description: Kullanıcı tarafından sağlanan key/value metaveri.
+      additionalProperties: true
+    EvidenceItem:
+      type: object
+      properties:
+        id:
+          type: string
+        filename:
+          type: string
+        sha256:
+          type: string
+          description: İçerik için onaltılık SHA-256 özeti.
+        size:
+          type: integer
+          format: int64
+        uploadedAt:
+          type: string
+          format: date-time
+        metadata:
+          $ref: '#/components/schemas/EvidenceMetadata'
+        contentEncoding:
+          type: string
+          enum: [base64]
+      required:
+        - id
+        - filename
+        - sha256
+        - size
+        - uploadedAt
+        - metadata
+        - contentEncoding
+    EvidenceItemWithContent:
+      allOf:
+        - $ref: '#/components/schemas/EvidenceItem'
+        - type: object
+          properties:
+            content:
+              type: string
+              description: Base64 kodlu içerik.
+    EvidenceUploadRequest:
+      type: object
+      required:
+        - filename
+        - content
+        - metadata
+      properties:
+        filename:
+          type: string
+        content:
+          type: string
+          description: Base64 kodlu dosya içeriği.
+        metadata:
+          type: object
+          properties:
+            sha256:
+              type: string
+              description: İçerik için beklenen SHA-256 özeti.
+            size:
+              type: integer
+              description: Bayt cinsinden beklenen dosya boyutu.
+          additionalProperties: true
+    ComplianceRequirement:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum: [covered, partial, missing]
+        title:
+          type: string
+        evidenceIds:
+          type: array
+          items:
+            type: string
+    ComplianceSummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        covered:
+          type: integer
+        partial:
+          type: integer
+        missing:
+          type: integer
+      required: [total, covered, partial, missing]
+    ComplianceMatrix:
+      type: object
+      properties:
+        project:
+          type: string
+        level:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        summary:
+          $ref: '#/components/schemas/ComplianceSummary'
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceRequirement'
+      required: [summary, requirements]
+    CoverageSummary:
+      type: object
+      properties:
+        statements:
+          type: number
+        branches:
+          type: number
+        functions:
+          type: number
+        lines:
+          type: number
+    ComplianceRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        sha256:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        matrix:
+          $ref: '#/components/schemas/ComplianceMatrix'
+        coverage:
+          $ref: '#/components/schemas/CoverageSummary'
+        metadata:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - sha256
+        - createdAt
+        - matrix
+        - coverage
+    ComplianceSubmission:
+      type: object
+      required:
+        - matrix
+        - coverage
+        - sha256
+      properties:
+        matrix:
+          $ref: '#/components/schemas/ComplianceMatrix'
+        coverage:
+          $ref: '#/components/schemas/CoverageSummary'
+        metadata:
+          type: object
+          additionalProperties: true
+        sha256:
+          type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1453,6 +1453,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "express": ">= 4.11"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -14958,6 +14970,7 @@
         "@soipack/report": "0.1.0",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.0.0",
         "helmet": "^7.2.0",
         "jose": "^5.3.0",
         "multer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "format:check": "prettier \"**/*.{ts,tsx,js,json,md,yml,yaml}\" --check",
     "demo": "bash examples/minimal/demo.sh",
     "demo:test": "node examples/minimal/verify-demo.js",
+    "test:server": "npm run test --workspace @soipack/server",
+    "test:cli": "npm run test --workspace @soipack/cli",
     "healthcheck:verify": "node scripts/verify-healthcheck.js",
     "ui": "npm run dev --workspace @soipack/ui",
     "test:adapters": "npm run test --workspace @soipack/adapters",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.0.0",
     "multer": "^2.0.0",
     "dotenv": "^16.4.5",
     "helmet": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      express-rate-limit:
+        specifier: ^7.0.0
+        version: 7.5.1(express@4.21.2)
       helmet:
         specifier: ^7.2.0
         version: 7.2.0
@@ -2410,6 +2413,12 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -7138,6 +7147,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-rate-limit@7.5.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
 
   express@4.21.2:
     dependencies:


### PR DESCRIPTION
## Summary
- align the compliance creation integration test with the server's canonical payload hashing so evidence references validate
- normalize ingest pipeline compliance and coverage summaries and extend CLI tests to prove manifest hashing and tamper detection
- keep the CLI packaging flow and OpenAPI docs consistent with the new endpoints

## Testing
- npm run test:server
- npm run test --workspace @soipack/cli -- --runInBand --verbose
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d18d0ecd5c83289ba44cd375ce71ee