### PR TITLE
Add PKCS#11 hardware signing support

### DIFF
--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1,0 +1,98 @@
+# Workspaces API
+
+## GET /v1/workspaces/{workspaceId}/documents/{documentId}
+
+Belirli bir çalışma alanı belgesinin son revizyonunu, sayfalı yorumlarını ve imza geçmişini döndürür. İstek, JWT token'ı ve geçerli bir SOIPack lisans anahtarını gerektirir.
+
+### Gerekli Başlıklar
+- `Authorization: Bearer <token>`
+- `X-SOIPACK-License: <base64>`
+
+### Path Parametreleri
+- `workspaceId` – Belgenin ait olduğu çalışma alanı kimliği.
+- `documentId` – Erişilecek belge kimliği.
+
+### Sorgu Parametreleri
+- `cursor` *(opsiyonel)* – Yorumları sayfalamak için bir önceki yanıttan alınan imleç değeri.
+- `limit` *(opsiyonel)* – Döndürülecek maksimum yorum sayısı (1-100 arası, varsayılan 20).
+
+### Örnek İstek
+```http
+GET /v1/workspaces/avionics/documents/requirements?limit=10 HTTP/1.1
+Authorization: Bearer eyJhbGciOi...
+X-SOIPACK-License: ZXhhbXBsZS1saWNlbnNl
+```
+
+### Yanıt Gövdesi
+```json
+{
+  "document": {
+    "id": "requirements",
+    "tenantId": "tenant-1",
+    "workspaceId": "avionics",
+    "kind": "requirements",
+    "title": "Flight Controls",
+    "createdAt": "2024-03-01T09:00:00.000Z",
+    "updatedAt": "2024-03-05T18:42:10.000Z",
+    "revision": {
+      "id": "rev-3",
+      "number": 3,
+      "hash": "5b2d0ce5f7a9a1d4",
+      "authorId": "alice",
+      "createdAt": "2024-03-05T18:42:10.000Z",
+      "content": [
+        {
+          "id": "REQ-001",
+          "title": "The aircraft shall enter fail-safe mode on sensor disagreement.",
+          "description": "Primary and secondary sensor suites must be continuously cross-checked.",
+          "status": "draft",
+          "tags": ["safety", "level-a"]
+        }
+      ]
+    }
+  },
+  "comments": [
+    {
+      "id": "c1",
+      "documentId": "requirements",
+      "revisionId": "rev-3",
+      "tenantId": "tenant-1",
+      "workspaceId": "avionics",
+      "authorId": "qa-lead",
+      "body": "Lütfen sensör doğrulama testi için referans ekleyin.",
+      "createdAt": "2024-03-05T19:10:00.000Z"
+    }
+  ],
+  "signoffs": [
+    {
+      "id": "s1",
+      "documentId": "requirements",
+      "revisionId": "rev-2",
+      "tenantId": "tenant-1",
+      "workspaceId": "avionics",
+      "revisionHash": "1f0c9bd4a1f5d6b2",
+      "status": "pending",
+      "requestedBy": "alice",
+      "requestedFor": "der",
+      "createdAt": "2024-03-02T14:00:00.000Z",
+      "updatedAt": "2024-03-02T14:00:00.000Z",
+      "approvedAt": null,
+      "rejectedAt": null
+    }
+  ],
+  "nextCursor": null
+}
+```
+
+### Yanıt Alanları
+- `document` – Belgenin meta verileri ve son revizyonu.
+  - `revision.hash` – Son revizyonun normalleştirilmiş (küçük harf) karması.
+  - `revision.content` – Gereksinim kayıtlarının listesi (ID, başlık, açıklama, durum, etiketler).
+- `comments` – Artan kronolojik sırada yorumlar.
+- `signoffs` – İlk imza isteğinden itibaren sıralanmış imza kayıtları. `status` alanı `pending` veya `approved` değerini alır.
+- `nextCursor` – Daha fazla yorum olduğunda kullanılacak imleç; aksi halde `null`.
+
+### Hata Kodları
+- `400 INVALID_REQUEST` – Geçersiz sayfalama parametreleri.
+- `403 INSUFFICIENT_SCOPE` – Kullanıcı gerekli rol veya scope'a sahip değil.
+- `404 WORKSPACE_DOCUMENT_NOT_FOUND` – Belge mevcut değil ya da kiracıyla eşleşmiyor.

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -13,6 +13,8 @@ SOIPack raporlama paketi; uyum matrisi, izlenebilirlik ve kapsam çıktıları i
 - **Kapsam Uyarıları** – MC/DC veya karar metrikleri eksik olduğunda gösterilen okunaklı uyarı listesi.
 - **Risk Profili** – Kapsam boşlukları, test hataları, statik analiz bulguları ve audit bayraklarının ağırlıklı risk skoru.
 - **Signoff Zaman Çizelgesi** – Workspace belgeleri için kimlerin signoff talep edip onayladığını gösteren kronolojik akış.
+- **Değişiklik Talepleri Birikimi** – Jira üzerinden takip edilen DO-178C değişiklik isteklerinin durumu, atanan kişi ve ekleriyle birlikte listelenir.
+- **Ledger Attestasyon Özeti** – Kanıt defteri attestation farkları sayesinde hangi kanıtların eklendiği ya da çıkarıldığı hızlıca gözlemlenir.
 
 Rapor başlığında versiyon, manifest kimliği ve otomatik olarak `YYYY-MM-DD HH:MM UTC` formatında yazılmış rapor tarihi yer alır. Özet bölümünde hem uyum hem de kapsam metrikleri (ör. “Satır Kapsamı 68.8%”) tek satırda gösterilir.
 
@@ -21,6 +23,8 @@ Rapor başlığında versiyon, manifest kimliği ve otomatik olarak `YYYY-MM-DD 
 Risk bölümü, `@soipack/engine` tarafından sağlanan risk bloğunu görselleştirir. Breakdown kartları her faktörün ağırlığını ve toplam skora katkısını gösterirken, kapsam eğilim grafiği geçmiş snapshot verilerinden eğimi tahmin ederek ekiplerin trendleri tartışmasına yardımcı olur. Eksik sinyal listesi, risk hesabında varsayılan kabul edilen metrikleri vurgular.
 
 Signoff zaman çizelgesi ise workspace servisinden gelen `pending` ve `approved` signoff kayıtlarını ISO zaman damgalarıyla kronolojik olarak sunar. Her olayda aktör bilgisi ve varsa anahtar/parmak izi özeti görüntülenir. Bu sayede raporu okuyan denetçiler, kanıt zincirinin kimler tarafından imzalandığını ve sürecin nerede beklediğini kolayca takip eder.
+
+Değişiklik talepleri bölümü, Jira Cloud adaptörünün `fetchJiraChangeRequests` çıktısını aynen yansıtır. Her satırda talebin anahtarı, özet bilgisi, güncel durum/öncelik ve mevcut geçiş aksiyonları gösterilir. Ekler satırı, ilgili talebe yüklenen etki analizleri veya test raporlarını bağlantılı biçimde sunar. Ledger attestation tablosu ise uyum defterindeki en son snapshot köklerini ve hangi kanıt kimliklerinin eklendiğini/çıkarıldığını rozetlerle özetler; böylece denetçi defter farkını tek bakışta inceleyebilir.
 
 ## HTML doğrulaması
 

--- a/docs/soipack_user_guide.md
+++ b/docs/soipack_user_guide.md
@@ -212,6 +212,22 @@ Arayüzdeki temel görünüm aşağıda özetlenmiştir:
 
 ![SOIPack UI pipeline görünümü](images/ui-pipeline.png)
 
+#### Gereksinim Editörü
+
+`Requirements Editor` sekmesi, çalışma alanı belgelerini API üzerinden doğrudan düzenlemenizi sağlar. Sayfaya token ve lisans bilgileriyle eriştiğinizde uygulama `/v1/workspaces/{workspaceId}/documents/{documentId}` uç noktasından en son revizyonu, yorumları ve imza isteklerini çeker. Revizyon ızgarasında her satır bir gereksinimi temsil eder; kimlik, başlık, açıklama, durum ve etiketler alanları hücre içinde düzenlenebilir. `Add requirement` düğmesi boş bir satır ekler.
+
+Değişiklikler kaydedildiğinde istemci, beklenen karma değerini (`expectedHash`) mevcut revizyon hash'iyle doldurarak `PUT /v1/workspaces/{workspaceId}/documents/{documentId}` çağrısı yapar. Sunucu yeni revizyonu dönerse hash otomatik güncellenir ve ızgara temizlenir; aksi halde çakışma uyarısı görüntülenir. Sayfanın sağındaki yorum paneli, revizyonla ilişkili geribildirimleri listeler ve `Add comment` alanı yeni notların aynı revizyona eklenmesini sağlar.
+
+İmza süreci için `Request signoff` düğmesi modal açar. Bu pencerede hedef rolü veya kullanıcı kimliğini girerek `POST /v1/workspaces/{workspaceId}/signoffs` çağrısını tetikleyebilir, sonuç olarak dönen kayıt hemen listelenen imza geçmişine eklenir. Onay süreci tamamlandığında signoff kartındaki durum etiketi güncellenir; böylece gereksinim setinin hangi revizyonunun denetimden geçtiği arayüzden izlenebilir.
+
+#### RBAC Kullanıcı Yönetimi
+
+`Yönetici Kullanıcılar` sekmesi yalnızca `admin` rolüne sahip oturumlarda görünür ve tüm çağrılar için token ile lisans anahtarının girilmiş olmasını zorunlu kılar. Sekmeye ilk kez girildiğinde istemci `GET /v1/admin/roles` ve `GET /v1/admin/users` çağrılarını birlikte çalıştırarak mevcut rol tanımlarını ve kullanıcı listesini önbelleğe alır; kimlik doğrulama eksikse arayüz bunu uyarı kartı ile bildirir ve istekleri tekrar denemez.
+
+`Yeni Kullanıcı` eylemi e-posta, görünen ad ve rol seçimi için bir form açar. Kaydetme işlemi `POST /v1/admin/users` uç noktasına yönlendirilir ve sunucu geçici parola dönerse bu bilgi modal kapandıktan sonra “Güncelleme tamamlandı” alert bileşeninde gösterilir. Mevcut bir kaydı `Düzenle` bağlantısıyla açtığınızda form alanları ilgili kullanıcı verileriyle doldurulur; gönderim `PUT /v1/admin/users/{userId}` çağrısıyla rol atamalarını günceller. Güncellenen kullanıcıya ait doğrulama sırrı rota içerisinde dönerse arayüz hemen aynı alert bileşeniyle yeni sırrı yayınlar.
+
+Her kullanıcı satırındaki `Sır Sıfırla` işlemi, söz konusu hesabın erişim anahtarını `rotateSecret: true` parametresiyle sıfırlar ve dönen yeni sırrı operatörle paylaşır. `Sil` butonu `DELETE /v1/admin/users/{userId}` çağrısını tetikler; işlem başarılı olduğunda satır hemen tablodan kaldırılır. Tüm aksiyonlar msw tabanlı testlerde sahte sunucu yanıtlarıyla doğrulanır ve `ApiError` istisnaları formun altındaki hata panelinde görüntülenerek operatöre gerekli düzeltme adımlarını iletir.
+
 ## Hata Kodları
 SOIPack CLI süreçleri başarı ve başarısızlık durumlarını aşağıdaki çıkış kodlarıyla bildirir:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint \"{packages,docs}/**/*.{ts,tsx}\" --max-warnings=0",
     "test": "jest",
     "server": "tsx packages/server/src/start.ts",
-    "openapi:validate": "redocly lint packages/server/openapi.yaml",
+    "openapi:validate": "npx --yes @redocly/cli@2.2.0 lint packages/server/openapi.yaml",
     "e2e:api": "tsx scripts/e2e-api.ts",
     "format": "prettier \"**/*.{ts,tsx,js,json,md,yml,yaml}\" --write",
     "format:check": "prettier \"**/*.{ts,tsx,js,json,md,yml,yaml}\" --check",

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -19,6 +19,13 @@ export { fetchPolarionArtifacts } from './polarion';
 export type { PolarionClientOptions } from './polarion';
 export { fetchJenkinsArtifacts } from './jenkins';
 export type { JenkinsClientOptions } from './jenkins';
+export { fetchJiraChangeRequests } from './jiraCloud';
+export type {
+  JiraCloudClientOptions,
+  JiraChangeRequest,
+  JiraChangeRequestAttachment,
+  JiraChangeRequestTransition,
+} from './jiraCloud';
 
 export interface AdapterMetadata {
   name: string;

--- a/packages/adapters/src/jiraCloud.test.ts
+++ b/packages/adapters/src/jiraCloud.test.ts
@@ -1,0 +1,252 @@
+import http from 'http';
+import { AddressInfo } from 'net';
+
+import { fetchJiraChangeRequests } from './jiraCloud';
+
+const listen = (server: http.Server): Promise<AddressInfo> =>
+  new Promise((resolve) => {
+    server.listen(0, () => {
+      resolve(server.address() as AddressInfo);
+    });
+  });
+
+const close = (server: http.Server): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+describe('fetchJiraChangeRequests', () => {
+  it('retrieves paginated change requests with transitions and attachments', async () => {
+    const requests: string[] = [];
+
+    const server = http.createServer((req, res) => {
+      if (!req.url) {
+        res.statusCode = 400;
+        res.end();
+        return;
+      }
+
+      requests.push(req.url);
+
+      if (req.url.startsWith('/rest/api/3/search') && req.url.includes('startAt=0')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            startAt: 0,
+            maxResults: 2,
+            total: 3,
+            issues: [
+              {
+                id: '1001',
+                key: 'CR-1',
+                fields: {
+                  summary: 'Update DAL A requirements',
+                  status: { name: 'In Progress', statusCategory: { name: 'In Progress' } },
+                  assignee: { displayName: 'Alex Pilot' },
+                  updated: '2024-09-01T10:00:00Z',
+                  priority: { name: 'High' },
+                  issuetype: { name: 'Change Request' },
+                  attachment: [
+                    {
+                      id: 'att-1',
+                      filename: 'impact-analysis.pdf',
+                      mimeType: 'application/pdf',
+                      size: 2048,
+                      content: 'https://jira.example.com/secure/attachment/att-1',
+                      created: '2024-09-01T09:55:00Z',
+                    },
+                  ],
+                },
+              },
+              {
+                id: '1002',
+                key: 'CR-2',
+                fields: {
+                  summary: 'Audit configuration management plan',
+                  status: { name: 'Ready for Review', statusCategory: { name: 'To Do' } },
+                  assignee: null,
+                  updated: '2024-09-01T08:30:00Z',
+                  priority: { name: 'Medium' },
+                  issuetype: { name: 'Problem' },
+                  attachment: [],
+                },
+              },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (req.url.startsWith('/rest/api/3/search') && req.url.includes('startAt=2')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            startAt: 2,
+            maxResults: 2,
+            total: 3,
+            issues: [
+              {
+                id: '1003',
+                key: 'CR-3',
+                fields: {
+                  summary: 'Propagate software build for lab',
+                  status: { name: 'In Review', statusCategory: { name: 'In Progress' } },
+                  assignee: { displayName: 'Jamie QA' },
+                  updated: '2024-09-01T07:15:00Z',
+                  priority: { name: 'Low' },
+                  issuetype: { name: 'Change Request' },
+                  attachment: null,
+                },
+              },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (req.url.startsWith('/rest/api/3/issue/1001/transitions')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            transitions: [
+              { id: '1', name: 'Submit for Review', to: { name: 'Ready for Review', statusCategory: { name: 'To Do' } } },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (req.url.startsWith('/rest/api/3/issue/1002/transitions')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ transitions: [] }));
+        return;
+      }
+
+      if (req.url.startsWith('/rest/api/3/issue/1003/transitions')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            transitions: [
+              { id: '3', name: 'Approve', to: { name: 'Ready for Release', statusCategory: { name: 'Done' } } },
+            ],
+          }),
+        );
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end('Not Found');
+    });
+
+    try {
+      const address = await listen(server);
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+
+      const result = await fetchJiraChangeRequests({
+        baseUrl,
+        projectKey: 'DO178',
+        authToken: 'token',
+        pageSize: 2,
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({
+        key: 'CR-1',
+        summary: 'Update DAL A requirements',
+        assignee: 'Alex Pilot',
+        priority: 'High',
+      });
+      expect(result[0].attachments).toHaveLength(1);
+      expect(result[0].attachments[0]).toMatchObject({ filename: 'impact-analysis.pdf', url: expect.stringContaining('attachment') });
+      expect(result[0].transitions[0]).toMatchObject({ name: 'Submit for Review', toStatus: 'Ready for Review' });
+      expect(result[1]).toMatchObject({ key: 'CR-2', status: 'Ready for Review', assignee: undefined });
+      expect(result[2]).toMatchObject({ key: 'CR-3', transitions: [{ name: 'Approve', category: 'Done' }] });
+
+      const searchRequests = requests.filter((entry) => entry.startsWith('/rest/api/3/search'));
+      expect(searchRequests).toHaveLength(2);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('retries when Jira returns HTTP 429 with Retry-After header', async () => {
+    let searchCount = 0;
+
+    const server = http.createServer((req, res) => {
+      if (!req.url) {
+        res.statusCode = 400;
+        res.end();
+        return;
+      }
+
+      if (req.url.startsWith('/rest/api/3/search')) {
+        searchCount += 1;
+        if (searchCount === 1) {
+          res.statusCode = 429;
+          res.setHeader('Retry-After', '0.05');
+          res.end('Rate limited');
+          return;
+        }
+
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            startAt: 0,
+            maxResults: 1,
+            total: 1,
+            issues: [
+              {
+                id: '2001',
+                key: 'CR-10',
+                fields: {
+                  summary: 'Reset actuator tolerance',
+                  status: { name: 'In Progress', statusCategory: { name: 'In Progress' } },
+                  assignee: { displayName: 'Morgan Systems' },
+                  updated: '2024-09-02T11:22:33Z',
+                  priority: { name: 'High' },
+                  issuetype: { name: 'Change Request' },
+                  attachment: [],
+                },
+              },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (req.url?.startsWith('/rest/api/3/issue/2001/transitions')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ transitions: [] }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end('Not Found');
+    });
+
+    try {
+      const address = await listen(server);
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+
+      const result = await fetchJiraChangeRequests({
+        baseUrl,
+        projectKey: 'SAFETY',
+        authToken: 'token',
+        rateLimitDelaysMs: [10, 25],
+      });
+
+      expect(searchCount).toBe(2);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ key: 'CR-10', assignee: 'Morgan Systems' });
+    } finally {
+      await close(server);
+    }
+  });
+});
+

--- a/packages/adapters/src/jiraCloud.ts
+++ b/packages/adapters/src/jiraCloud.ts
@@ -1,0 +1,311 @@
+import { HttpError, type HttpRequestOptions, requestJson } from './utils/http';
+
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_MAX_PAGES = 20;
+const DEFAULT_RATE_LIMIT_DELAYS_MS = [500, 1000, 2000, 4000];
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const parseRetryAfter = (error: HttpError): number | undefined => {
+  const header = error.headers?.['retry-after'];
+  if (!header) {
+    return undefined;
+  }
+
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number.parseFloat(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const absolute = Date.parse(value);
+  if (!Number.isNaN(absolute)) {
+    const delta = absolute - Date.now();
+    return delta > 0 ? delta : undefined;
+  }
+
+  return undefined;
+};
+
+const requestWithBackoff = async <T>(
+  options: HttpRequestOptions,
+  attempt: number,
+  rateLimitDelays: number[],
+): Promise<T> => {
+  try {
+    return await requestJson<T>(options);
+  } catch (error) {
+    if (error instanceof HttpError && error.statusCode === 429 && attempt < rateLimitDelays.length) {
+      const retryDelay = parseRetryAfter(error) ?? rateLimitDelays[attempt];
+      if (retryDelay > 0) {
+        await sleep(retryDelay);
+      }
+      return requestWithBackoff(options, attempt + 1, rateLimitDelays);
+    }
+    throw error;
+  }
+};
+
+interface JiraIssueFieldUser {
+  displayName?: string | null;
+}
+
+interface JiraIssueFieldStatus {
+  name?: string | null;
+  statusCategory?: {
+    name?: string | null;
+  } | null;
+}
+
+interface JiraIssueFieldPriority {
+  name?: string | null;
+}
+
+interface JiraIssueAttachment {
+  id?: string | number;
+  filename?: string | null;
+  size?: number | null;
+  mimeType?: string | null;
+  content?: string | null;
+  created?: string | null;
+}
+
+interface JiraIssueFields {
+  summary?: string | null;
+  status?: JiraIssueFieldStatus | null;
+  assignee?: JiraIssueFieldUser | null;
+  updated?: string | null;
+  priority?: JiraIssueFieldPriority | null;
+  issuetype?: { name?: string | null } | null;
+  attachment?: JiraIssueAttachment[] | null;
+}
+
+interface JiraIssue {
+  id: string;
+  key: string;
+  fields: JiraIssueFields;
+}
+
+interface JiraSearchResponse {
+  startAt?: number;
+  maxResults?: number;
+  total?: number;
+  issues?: JiraIssue[];
+}
+
+interface JiraTransitionRecord {
+  id: string;
+  name: string;
+  to?: {
+    name?: string | null;
+    statusCategory?: {
+      name?: string | null;
+    } | null;
+  } | null;
+}
+
+interface JiraTransitionResponse {
+  transitions?: JiraTransitionRecord[];
+}
+
+export interface JiraChangeRequestTransition {
+  id: string;
+  name: string;
+  toStatus: string;
+  category?: string;
+}
+
+export interface JiraChangeRequestAttachment {
+  id: string;
+  filename: string;
+  url?: string;
+  size?: number;
+  mimeType?: string;
+  createdAt?: string;
+}
+
+export interface JiraChangeRequest {
+  id: string;
+  key: string;
+  summary: string;
+  status: string;
+  statusCategory?: string;
+  assignee?: string | null;
+  updatedAt?: string;
+  priority?: string | null;
+  issueType?: string | null;
+  url: string;
+  transitions: JiraChangeRequestTransition[];
+  attachments: JiraChangeRequestAttachment[];
+}
+
+export interface JiraCloudClientOptions {
+  baseUrl: string;
+  projectKey: string;
+  authToken?: string;
+  email?: string;
+  jql?: string;
+  pageSize?: number;
+  maxPages?: number;
+  timeoutMs?: number;
+  rateLimitDelaysMs?: number[];
+}
+
+const buildAuthHeader = (options: JiraCloudClientOptions): string | undefined => {
+  if (options.email && options.authToken) {
+    const credentials = Buffer.from(`${options.email}:${options.authToken}`).toString('base64');
+    return `Basic ${credentials}`;
+  }
+  if (options.authToken) {
+    return `Bearer ${options.authToken}`;
+  }
+  return undefined;
+};
+
+const normalizeSummary = (issue: JiraIssue): string => issue.fields.summary?.trim() || issue.key;
+
+const normalizeStatus = (issue: JiraIssue): { name: string; category?: string } => {
+  const statusName = issue.fields.status?.name?.trim();
+  const statusCategory = issue.fields.status?.statusCategory?.name?.trim();
+  return { name: statusName || 'Bilinmiyor', category: statusCategory || undefined };
+};
+
+const normalizeAttachments = (attachments: JiraIssueAttachment[] | null | undefined): JiraChangeRequestAttachment[] => {
+  if (!attachments || attachments.length === 0) {
+    return [];
+  }
+  return attachments.map((attachment) => ({
+    id: attachment.id !== undefined ? String(attachment.id) : 'unknown',
+    filename: attachment.filename?.trim() || 'attachment',
+    url: attachment.content ?? undefined,
+    size: typeof attachment.size === 'number' ? attachment.size : undefined,
+    mimeType: attachment.mimeType ?? undefined,
+    createdAt: attachment.created ?? undefined,
+  }));
+};
+
+const normalizeTransitions = (
+  transitions: JiraTransitionRecord[] | null | undefined,
+): JiraChangeRequestTransition[] => {
+  if (!transitions || transitions.length === 0) {
+    return [];
+  }
+  return transitions.map((transition) => ({
+    id: transition.id,
+    name: transition.name,
+    toStatus: transition.to?.name ?? 'Bilinmiyor',
+    category: transition.to?.statusCategory?.name ?? undefined,
+  }));
+};
+
+const buildIssueUrl = (options: JiraCloudClientOptions, issue: JiraIssue): string => {
+  try {
+    return new URL(`/browse/${issue.key}`, options.baseUrl).toString();
+  } catch {
+    return issue.key;
+  }
+};
+
+export const fetchJiraChangeRequests = async (
+  options: JiraCloudClientOptions,
+): Promise<JiraChangeRequest[]> => {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  const authHeader = buildAuthHeader(options);
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  }
+
+  const pageSize = options.pageSize && options.pageSize > 0 ? Math.trunc(options.pageSize) : DEFAULT_PAGE_SIZE;
+  const maxPages = options.maxPages && options.maxPages > 0 ? Math.trunc(options.maxPages) : DEFAULT_MAX_PAGES;
+  const rateLimitDelays =
+    options.rateLimitDelaysMs && options.rateLimitDelaysMs.length > 0
+      ? options.rateLimitDelaysMs
+      : DEFAULT_RATE_LIMIT_DELAYS_MS;
+
+  const defaultJql = `project = "${options.projectKey}" AND issuetype in ("Change Request", "Problem") AND "Compliance Standard" = "DO-178C" ORDER BY updated DESC`;
+  const jql = options.jql?.trim().length ? options.jql : defaultJql;
+
+  const changeRequests: JiraChangeRequest[] = [];
+  let startAt = 0;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const searchUrl = new URL('/rest/api/3/search', options.baseUrl);
+    searchUrl.searchParams.set('jql', jql);
+    searchUrl.searchParams.set('startAt', String(startAt));
+    searchUrl.searchParams.set('maxResults', String(pageSize));
+    searchUrl.searchParams.set('fields', 'summary,status,assignee,updated,priority,issuetype,attachment');
+
+    const searchResponse = await requestWithBackoff<JiraSearchResponse>(
+      {
+        url: searchUrl,
+        headers,
+        timeoutMs: options.timeoutMs,
+      },
+      0,
+      rateLimitDelays,
+    );
+
+    const issues = searchResponse.issues ?? [];
+    if (issues.length === 0) {
+      break;
+    }
+
+    const transitionPayloads = await Promise.all(
+      issues.map(async (issue) => {
+        const transitionsUrl = new URL(`/rest/api/3/issue/${issue.id}/transitions`, options.baseUrl);
+        transitionsUrl.searchParams.set('expand', 'transitions.fields');
+        try {
+          const response = await requestWithBackoff<JiraTransitionResponse>(
+            {
+              url: transitionsUrl,
+              headers,
+              timeoutMs: options.timeoutMs,
+            },
+            0,
+            rateLimitDelays,
+          );
+          return normalizeTransitions(response.transitions);
+        } catch (error) {
+          if (error instanceof HttpError && error.statusCode === 404) {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    );
+
+    issues.forEach((issue, index) => {
+      const status = normalizeStatus(issue);
+      changeRequests.push({
+        id: issue.id,
+        key: issue.key,
+        summary: normalizeSummary(issue),
+        status: status.name,
+        statusCategory: status.category,
+        assignee: issue.fields.assignee?.displayName ?? undefined,
+        updatedAt: issue.fields.updated ?? undefined,
+        priority: issue.fields.priority?.name ?? undefined,
+        issueType: issue.fields.issuetype?.name ?? undefined,
+        url: buildIssueUrl(options, issue),
+        transitions: transitionPayloads[index] ?? [],
+        attachments: normalizeAttachments(issue.fields.attachment),
+      });
+    });
+
+    startAt += issues.length;
+    const total = searchResponse.total ?? startAt;
+    if (startAt >= total) {
+      break;
+    }
+  }
+
+  return changeRequests;
+};
+

--- a/packages/adapters/src/utils/http.ts
+++ b/packages/adapters/src/utils/http.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import http, { type IncomingHttpHeaders } from 'http';
 import https from 'https';
 
 export interface HttpRequestOptions {
@@ -10,7 +10,12 @@ export interface HttpRequestOptions {
 }
 
 export class HttpError extends Error {
-  constructor(public readonly statusCode: number, public readonly statusMessage: string, message?: string) {
+  constructor(
+    public readonly statusCode: number,
+    public readonly statusMessage: string,
+    message?: string,
+    public readonly headers?: IncomingHttpHeaders,
+  ) {
     super(message ?? `HTTP ${statusCode} ${statusMessage}`);
     this.name = 'HttpError';
   }
@@ -53,7 +58,7 @@ export const requestJson = async <T>(options: HttpRequestOptions): Promise<T> =>
           const payload = Buffer.concat(chunks).toString('utf8');
 
           if (statusCode < 200 || statusCode >= 300) {
-            reject(new HttpError(statusCode, statusMessage, payload || undefined));
+            reject(new HttpError(statusCode, statusMessage, payload || undefined, response.headers));
             return;
           }
 

--- a/packages/packager/src/security/signer.test.ts
+++ b/packages/packager/src/security/signer.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, sign as signData, X509Certificate } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -11,14 +11,19 @@ import {
 
 const DEV_CERT_BUNDLE_PATH = path.resolve(__dirname, '../../../../test/certs/dev.pem');
 const CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/;
+const PRIVATE_KEY_PATTERN = /-----BEGIN (?:RSA )?PRIVATE KEY-----[\s\S]+?-----END (?:RSA )?PRIVATE KEY-----/;
 
-const loadDevCredentials = (): { bundlePem: string; certificatePem: string } => {
+const loadDevCredentials = (): { bundlePem: string; certificatePem: string; privateKeyPem: string } => {
   const bundlePem = readFileSync(DEV_CERT_BUNDLE_PATH, 'utf8');
   const certificateMatch = bundlePem.match(CERTIFICATE_PATTERN);
+  const privateKeyMatch = bundlePem.match(PRIVATE_KEY_PATTERN);
   if (!certificateMatch) {
     throw new Error('Dev sertifikası bulunamadı.');
   }
-  return { bundlePem, certificatePem: certificateMatch[0] };
+  if (!privateKeyMatch) {
+    throw new Error('Dev özel anahtarı bulunamadı.');
+  }
+  return { bundlePem, certificatePem: certificateMatch[0], privateKeyPem: privateKeyMatch[0] };
 };
 
 const buildDigest = (value: string): string => createHash('sha256').update(value).digest('hex');
@@ -31,6 +36,170 @@ const baseManifest: Manifest = {
     { path: 'evidence/logs.csv', sha256: buildDigest('logs') },
   ],
 };
+
+type Pkcs11Attribute = { type: number; value?: Buffer };
+
+class MockPkcs11 {
+  public readonly slotId = 9;
+
+  private readonly privateKeyHandle = 0x01;
+
+  private readonly certificateHandle = 0x02;
+
+  private readonly attestationHandle = 0x03;
+
+  private readonly certificateDer: Buffer;
+
+  private readonly attestationValue: Buffer;
+
+  private lastTemplate: Pkcs11Attribute[] | undefined;
+
+  private sessionCounter = 100;
+
+  private readonly omitKey: boolean;
+
+  private readonly privateKeyPem?: string;
+
+  public loginPin?: string;
+
+  public lastSignedPayload?: Buffer;
+
+  public signMechanism?: number;
+
+  constructor({
+    certificatePem,
+    privateKeyPem,
+    attestation,
+    omitKey = false,
+  }: {
+    certificatePem: string;
+    privateKeyPem?: string;
+    attestation?: Buffer;
+    omitKey?: boolean;
+  }) {
+    this.privateKeyPem = privateKeyPem;
+    this.certificateDer = new X509Certificate(certificatePem).raw;
+    this.attestationValue = attestation ?? Buffer.from('attestation evidence');
+    this.omitKey = omitKey;
+  }
+
+  load(): void {
+    // noop for tests
+  }
+
+  C_Initialize(): void {
+    // noop
+  }
+
+  C_Finalize(): void {
+    // noop
+  }
+
+  C_GetSlotList(tokenPresent: boolean): number[] {
+    return tokenPresent ? [this.slotId] : [];
+  }
+
+  C_GetSlotInfo(): {
+    slotDescription: Buffer;
+    manufacturerID: Buffer;
+    hardwareVersion: { major: number; minor: number };
+    firmwareVersion: { major: number; minor: number };
+  } {
+    const slotDescription = Buffer.alloc(64);
+    slotDescription.write('YubiHSM Slot', 'utf8');
+    const manufacturerID = Buffer.alloc(32);
+    manufacturerID.write('Yubico', 'utf8');
+    return {
+      slotDescription,
+      manufacturerID,
+      hardwareVersion: { major: 1, minor: 3 },
+      firmwareVersion: { major: 4, minor: 2 },
+    };
+  }
+
+  C_GetTokenInfo(): {
+    label: string;
+    manufacturerID: string;
+    model: string;
+    serialNumber: string;
+  } {
+    return {
+      label: 'YubiHSM2-Test',
+      manufacturerID: 'Yubico',
+      model: 'YHSM2',
+      serialNumber: '000123456789',
+    };
+  }
+
+  C_OpenSession(): number {
+    this.sessionCounter += 1;
+    return this.sessionCounter;
+  }
+
+  C_CloseSession(): void {
+    // noop
+  }
+
+  C_Login(_session: number, _userType: number, pin: string): void {
+    this.loginPin = pin;
+  }
+
+  C_Logout(): void {
+    // noop
+  }
+
+  C_FindObjectsInit(_session: number, template: Pkcs11Attribute[]): void {
+    this.lastTemplate = template;
+  }
+
+  C_FindObjects(_session: number, _count: number): Array<number> {
+    if (!this.lastTemplate) {
+      return [];
+    }
+    const labelEntry = this.lastTemplate.find((attr) => attr.type === 0x00000003);
+    const label = labelEntry?.value?.toString('utf8');
+    if (label === 'SIGNING-KEY') {
+      return this.omitKey ? [] : [this.privateKeyHandle];
+    }
+    if (label === 'SIGNING-CERT') {
+      return [this.certificateHandle];
+    }
+    if (label === 'ATTEST') {
+      return [this.attestationHandle];
+    }
+    return [];
+  }
+
+  C_FindObjectsFinal(): void {
+    this.lastTemplate = undefined;
+  }
+
+  C_GetAttributeValue(
+    _session: number,
+    handle: number,
+    template: Pkcs11Attribute[],
+  ): Array<{ type: number; value: Buffer }> {
+    const value =
+      handle === this.certificateHandle
+        ? this.certificateDer
+        : handle === this.attestationHandle
+          ? this.attestationValue
+          : Buffer.alloc(0);
+    return template.map((attribute) => ({ type: attribute.type, value }));
+  }
+
+  C_SignInit(_session: number, mechanism: { mechanism: number }, _key: number): void {
+    this.signMechanism = mechanism.mechanism;
+  }
+
+  C_Sign(_session: number, data: Buffer): Buffer {
+    this.lastSignedPayload = Buffer.from(data);
+    if (!this.privateKeyPem) {
+      throw new Error('Mock private key missing');
+    }
+    return signData(null, data, this.privateKeyPem);
+  }
+}
 
 describe('security signer ledger integration', () => {
   it('embeds ledger metadata into the signature payload', () => {
@@ -108,5 +277,71 @@ describe('security signer ledger integration', () => {
 
     expect(verification.valid).toBe(false);
     expect(verification.reason).toBe('LEDGER_ROOT_MISSING');
+  });
+});
+
+describe('security signer pkcs11 integration', () => {
+  it('signs manifests via pkcs11 modules and returns hardware evidence', () => {
+    const { certificatePem, privateKeyPem } = loadDevCredentials();
+    const attestation = Buffer.from('mock-attestation');
+    const module = new MockPkcs11({
+      certificatePem,
+      privateKeyPem,
+      attestation,
+    });
+
+    const bundle = signManifestWithSecuritySigner(baseManifest, {
+      pkcs11: {
+        module,
+        slotIndex: 0,
+        pin: '000001',
+        privateKey: { label: 'SIGNING-KEY' },
+        certificate: { label: 'SIGNING-CERT' },
+        attestation: { label: 'ATTEST', format: 'yubihsm-x509' },
+      },
+    });
+
+    expect(module.loginPin).toBe('000001');
+    expect(module.signMechanism).toBe(0x0000108d);
+    expect(module.lastSignedPayload?.toString('utf8')).toContain('.');
+
+    expect(bundle.certificate).toContain('BEGIN CERTIFICATE');
+
+    const verification = verifyManifestSignatureWithSecuritySigner(baseManifest, bundle.signature, {
+      certificatePem: bundle.certificate,
+    });
+
+    expect(verification.valid).toBe(true);
+    expect(bundle.hardware).toEqual(
+      expect.objectContaining({
+        provider: 'PKCS11',
+        slot: expect.objectContaining({
+          id: module.slotId,
+          description: 'YubiHSM Slot',
+          tokenLabel: 'YubiHSM2-Test',
+          tokenSerial: '000123456789',
+        }),
+        attestation: {
+          format: 'yubihsm-x509',
+          data: attestation.toString('base64'),
+        },
+      }),
+    );
+  });
+
+  it('throws a descriptive error when the private key cannot be found', () => {
+    const { certificatePem } = loadDevCredentials();
+    const module = new MockPkcs11({ certificatePem, omitKey: true });
+
+    expect(() =>
+      signManifestWithSecuritySigner(baseManifest, {
+        pkcs11: {
+          module,
+          slotIndex: 0,
+          privateKey: { label: 'SIGNING-KEY' },
+          certificate: { label: 'SIGNING-CERT' },
+        },
+      }),
+    ).toThrow('PKCS#11 özel anahtarı bulunamadı.');
   });
 });

--- a/packages/packager/src/security/signer.ts
+++ b/packages/packager/src/security/signer.ts
@@ -29,6 +29,7 @@ export interface ManifestSignatureBundle {
   manifestDigest: ManifestDigest;
   ledgerRoot?: string | null;
   previousLedgerRoot?: string | null;
+  hardware?: HardwareSignatureMetadata;
 }
 
 export interface SecuritySignerOptions {
@@ -39,7 +40,101 @@ export interface SecuritySignerOptions {
   privateKeyPath?: string;
   privateKeyPem?: string;
   ledger?: LedgerProofMetadata;
+  pkcs11?: Pkcs11SigningOptions;
 }
+
+type Pkcs11Attribute = { type: number; value?: Buffer };
+
+interface Pkcs11Like {
+  load?(libraryPath: string): void;
+  C_Initialize(options?: unknown): void;
+  C_Finalize(): void;
+  C_GetSlotList(tokenPresent: boolean): Array<number | Buffer>;
+  C_GetSlotInfo(slot: number | Buffer): {
+    slotDescription: Buffer | string;
+    manufacturerID: Buffer | string;
+    hardwareVersion?: { major: number; minor: number };
+    firmwareVersion?: { major: number; minor: number };
+  };
+  C_GetTokenInfo(slot: number | Buffer): {
+    label?: string;
+    manufacturerID?: string;
+    model?: string;
+    serialNumber?: string;
+  };
+  C_OpenSession(slot: number | Buffer, flags: number): number;
+  C_CloseSession(session: number): void;
+  C_Login(session: number, userType: number, pin: string): void;
+  C_Logout(session: number): void;
+  C_FindObjectsInit(session: number, template: Pkcs11Attribute[]): void;
+  C_FindObjects(session: number, count: number): Array<Buffer | number>;
+  C_FindObjectsFinal(session: number): void;
+  C_GetAttributeValue(
+    session: number,
+    handle: Buffer | number,
+    template: Pkcs11Attribute[],
+  ): Array<{ type: number; value?: Buffer }>;
+  C_SignInit(
+    session: number,
+    mechanism: { mechanism: number; parameter?: Buffer | null },
+    key: Buffer | number,
+  ): void;
+  C_Sign(session: number, data: Buffer): Buffer;
+}
+
+export interface Pkcs11ObjectSelector {
+  label?: string;
+  idHex?: string;
+}
+
+export interface Pkcs11AttestationOptions extends Pkcs11ObjectSelector {
+  format?: string;
+}
+
+export interface Pkcs11SigningOptions {
+  libraryPath?: string;
+  slotId?: number;
+  slotIndex?: number;
+  pin?: string;
+  userType?: number;
+  privateKey: Pkcs11ObjectSelector & { label?: string };
+  certificate?: Pkcs11ObjectSelector;
+  attestation?: Pkcs11AttestationOptions;
+  mechanism?: number;
+  module?: Pkcs11Like;
+}
+
+export interface HardwareSignatureMetadata {
+  provider: 'PKCS11';
+  slot: {
+    id: number;
+    index: number;
+    description?: string;
+    manufacturer?: string;
+    hardwareVersion?: string;
+    firmwareVersion?: string;
+    tokenLabel?: string;
+    tokenModel?: string;
+    tokenManufacturer?: string;
+    tokenSerial?: string;
+  };
+  attestation?: {
+    format: string;
+    data: string;
+  };
+}
+
+const CKF_RW_SESSION = 0x00000002;
+const CKF_SERIAL_SESSION = 0x00000004;
+const CKU_USER = 1;
+const CKO_DATA = 0;
+const CKO_CERTIFICATE = 1;
+const CKO_PRIVATE_KEY = 3;
+const CKA_CLASS = 0x00000000;
+const CKA_LABEL = 0x00000003;
+const CKA_ID = 0x00000102;
+const CKA_VALUE = 0x00000011;
+const CKM_EDDSA = 0x0000108d;
 
 export type VerificationFailureReason =
   | 'FORMAT_INVALID'
@@ -94,6 +189,50 @@ const base64UrlDecode = (value: string): Buffer => {
   return Buffer.from(normalized + padding, 'base64');
 };
 
+const encodePkcs11Uint = (value: number): Buffer => {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value >>> 0, 0);
+  return buffer;
+};
+
+const normalizePkcs11String = (value?: string | Buffer | null): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value.trim() || undefined;
+  }
+  return value.toString('utf8').replace(/\0+$/, '').trim() || undefined;
+};
+
+const formatVersion = (version?: { major: number; minor: number }): string | undefined => {
+  if (!version) {
+    return undefined;
+  }
+  const major = version.major ?? 0;
+  const minor = version.minor ?? 0;
+  return `${major}.${minor.toString().padStart(2, '0')}`;
+};
+
+const readSlotId = (slot: number | Buffer): number => {
+  if (typeof slot === 'number') {
+    return slot;
+  }
+  if (slot.length >= 4) {
+    return slot.readUInt32LE(0);
+  }
+  return slot.readUIntLE(0, slot.length);
+};
+
+const safeRequire = (moduleName: string): any => {
+  try {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(moduleName);
+  } catch (error) {
+    return undefined;
+  }
+};
+
 const canonicalizeManifest = (manifest: Manifest & ManifestLedgerMetadata): Manifest => {
   const canonical: LedgerAwareManifest = {
     files: [...manifest.files]
@@ -143,6 +282,14 @@ const extractCredentialPair = (pemBundle: string): CredentialPair => {
   };
 };
 
+const extractCertificatePem = (pemContent: string): string => {
+  const certificateMatch = pemContent.match(CERTIFICATE_PATTERN);
+  if (!certificateMatch) {
+    throw new Error('Sertifika PEM içeriği bulunamadı.');
+  }
+  return certificateMatch[0];
+};
+
 const resolveCredentials = (options: SecuritySignerOptions = {}): CredentialPair => {
   if (options.certificatePem && options.privateKeyPem) {
     return {
@@ -188,16 +335,278 @@ const resolveCredentials = (options: SecuritySignerOptions = {}): CredentialPair
   return extractCredentialPair(defaultBundle);
 };
 
+const resolveCertificateOnly = (options: SecuritySignerOptions = {}): string | undefined => {
+  if (options.certificatePem) {
+    return options.certificatePem;
+  }
+
+  if (options.bundlePem) {
+    return extractCertificatePem(options.bundlePem);
+  }
+
+  if (options.bundlePath) {
+    return extractCertificatePem(readFileSync(options.bundlePath, 'utf8'));
+  }
+
+  if (options.certificatePath) {
+    return extractCertificatePem(readFileSync(options.certificatePath, 'utf8'));
+  }
+
+  return undefined;
+};
+
 const formatCertificateFromDer = (derBase64: string): string => {
   const chunks = derBase64.match(/.{1,64}/g) ?? [];
   return ['-----BEGIN CERTIFICATE-----', ...chunks, '-----END CERTIFICATE-----', ''].join('\n').trim();
+};
+
+const buildSigningPreparation = (
+  certificatePem: string,
+  digest: ManifestDigest,
+  ledgerRoot: string | null,
+  previousLedgerRoot: string | null,
+): { signingInput: string } => {
+  const x509 = new X509Certificate(certificatePem);
+  const header = {
+    alg: 'EdDSA',
+    typ: 'SOIManifest',
+    x5c: [x509.raw.toString('base64')],
+  };
+  const payload = {
+    digest: digest.hash,
+    algorithm: digest.algorithm,
+    ledgerRoot,
+    previousLedgerRoot,
+  };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+
+  return {
+    signingInput: `${encodedHeader}.${encodedPayload}`,
+  };
+};
+
+const buildBundleFromSignature = (
+  certificatePem: string,
+  digest: ManifestDigest,
+  ledgerRoot: string | null,
+  previousLedgerRoot: string | null,
+  signingInput: string,
+  signatureBuffer: Buffer,
+): ManifestSignatureBundle => ({
+  signature: `${signingInput}.${base64UrlEncode(signatureBuffer)}`,
+  certificate: certificatePem.trim(),
+  manifestDigest: digest,
+  ledgerRoot,
+  previousLedgerRoot,
+});
+
+const ensurePkcs11Module = (options: Pkcs11SigningOptions): Pkcs11Like => {
+  if (options.module) {
+    return options.module;
+  }
+
+  const pkcs11js = safeRequire('pkcs11js');
+  if (!pkcs11js || typeof pkcs11js.PKCS11 !== 'function') {
+    throw new Error('PKCS#11 modülü yüklenemedi. "pkcs11js" bağımlılığını ekleyin.');
+  }
+
+  const instance: Pkcs11Like = new pkcs11js.PKCS11();
+  if (options.libraryPath) {
+    instance.load?.(options.libraryPath);
+  }
+  return instance;
+};
+
+const selectPkcs11Slot = (
+  pkcs11: Pkcs11Like,
+  options: Pkcs11SigningOptions,
+): { slotHandle: number | Buffer; slotIndex: number } => {
+  const slots = pkcs11.C_GetSlotList(true);
+  if (!slots.length) {
+    throw new Error('PKCS#11 yuvası bulunamadı.');
+  }
+
+  if (typeof options.slotId === 'number') {
+    const index = slots.findIndex((slot) => readSlotId(slot) === options.slotId);
+    if (index === -1) {
+      throw new Error(`Belirtilen PKCS#11 yuvası bulunamadı: ${options.slotId}`);
+    }
+    return { slotHandle: slots[index], slotIndex: index };
+  }
+
+  const targetIndex = options.slotIndex ?? 0;
+  if (targetIndex < 0 || targetIndex >= slots.length) {
+    throw new Error(`PKCS#11 yuva indeksi geçersiz: ${targetIndex}`);
+  }
+
+  return { slotHandle: slots[targetIndex], slotIndex: targetIndex };
+};
+
+const findPkcs11ObjectHandle = (
+  pkcs11: Pkcs11Like,
+  session: number,
+  classType: number,
+  selector: Pkcs11ObjectSelector,
+): Buffer | number | undefined => {
+  const template: Pkcs11Attribute[] = [{ type: CKA_CLASS, value: encodePkcs11Uint(classType) }];
+  if (selector.label) {
+    template.push({ type: CKA_LABEL, value: Buffer.from(selector.label, 'utf8') });
+  }
+  if (selector.idHex) {
+    template.push({ type: CKA_ID, value: Buffer.from(selector.idHex, 'hex') });
+  }
+
+  pkcs11.C_FindObjectsInit(session, template);
+  try {
+    const [handle] = pkcs11.C_FindObjects(session, 1);
+    return handle;
+  } finally {
+    pkcs11.C_FindObjectsFinal(session);
+  }
+};
+
+const readPkcs11Attribute = (
+  pkcs11: Pkcs11Like,
+  session: number,
+  handle: Buffer | number,
+  attributeType = CKA_VALUE,
+): Buffer => {
+  const [attribute] = pkcs11.C_GetAttributeValue(session, handle, [{ type: attributeType }]);
+  if (!attribute || !attribute.value) {
+    throw new Error('PKCS#11 nesnesinden değer okunamadı.');
+  }
+  return attribute.value;
+};
+
+const signManifestWithPkcs11 = (
+  digest: ManifestDigest,
+  ledgerRoot: string | null,
+  previousLedgerRoot: string | null,
+  options: SecuritySignerOptions,
+): ManifestSignatureBundle => {
+  const pkcs11Options = options.pkcs11!;
+  if (!pkcs11Options.privateKey.label && !pkcs11Options.privateKey.idHex) {
+    throw new Error('PKCS#11 imzası için label veya idHex değerli bir özel anahtar seçicisi gereklidir.');
+  }
+
+  const pkcs11 = ensurePkcs11Module(pkcs11Options);
+  pkcs11.C_Initialize();
+
+  let session: number | undefined;
+  let loggedIn = false;
+
+  try {
+    const { slotHandle, slotIndex } = selectPkcs11Slot(pkcs11, pkcs11Options);
+    const slotInfo = pkcs11.C_GetSlotInfo(slotHandle);
+    const tokenInfo = pkcs11.C_GetTokenInfo(slotHandle);
+
+    session = pkcs11.C_OpenSession(slotHandle, CKF_SERIAL_SESSION | CKF_RW_SESSION);
+
+    if (pkcs11Options.pin) {
+      pkcs11.C_Login(session, pkcs11Options.userType ?? CKU_USER, pkcs11Options.pin);
+      loggedIn = true;
+    }
+
+    const privateKeyHandle = findPkcs11ObjectHandle(pkcs11, session, CKO_PRIVATE_KEY, pkcs11Options.privateKey);
+    if (!privateKeyHandle) {
+      throw new Error('PKCS#11 özel anahtarı bulunamadı.');
+    }
+
+    let certificatePem = resolveCertificateOnly(options);
+    if (!certificatePem) {
+      if (!pkcs11Options.certificate) {
+        throw new Error('PKCS#11 sertifikası bulunamadı. Sertifika bilgisi sağlayın.');
+      }
+      const certificateHandle = findPkcs11ObjectHandle(pkcs11, session, CKO_CERTIFICATE, pkcs11Options.certificate);
+      if (!certificateHandle) {
+        throw new Error('PKCS#11 sertifika nesnesi bulunamadı.');
+      }
+      const certificateDer = readPkcs11Attribute(pkcs11, session, certificateHandle);
+      certificatePem = formatCertificateFromDer(certificateDer.toString('base64'));
+    }
+
+    const trimmedCertificate = certificatePem.trim();
+    const { signingInput } = buildSigningPreparation(
+      trimmedCertificate,
+      digest,
+      ledgerRoot,
+      previousLedgerRoot,
+    );
+    pkcs11.C_SignInit(session, { mechanism: pkcs11Options.mechanism ?? CKM_EDDSA }, privateKeyHandle);
+    const signatureBuffer = pkcs11.C_Sign(session, Buffer.from(signingInput, 'utf8'));
+
+    const bundle = buildBundleFromSignature(
+      trimmedCertificate,
+      digest,
+      ledgerRoot,
+      previousLedgerRoot,
+      signingInput,
+      signatureBuffer,
+    );
+
+    const hardwareMetadata: HardwareSignatureMetadata = {
+      provider: 'PKCS11',
+      slot: {
+        id: readSlotId(slotHandle),
+        index: slotIndex,
+        description: normalizePkcs11String(slotInfo.slotDescription),
+        manufacturer: normalizePkcs11String(slotInfo.manufacturerID),
+        hardwareVersion: formatVersion(slotInfo.hardwareVersion),
+        firmwareVersion: formatVersion(slotInfo.firmwareVersion),
+        tokenLabel: normalizePkcs11String(tokenInfo.label),
+        tokenModel: normalizePkcs11String(tokenInfo.model),
+        tokenManufacturer: normalizePkcs11String(tokenInfo.manufacturerID),
+        tokenSerial: normalizePkcs11String(tokenInfo.serialNumber),
+      },
+    };
+
+    if (pkcs11Options.attestation && (pkcs11Options.attestation.label || pkcs11Options.attestation.idHex)) {
+      const attestationHandle = findPkcs11ObjectHandle(
+        pkcs11,
+        session,
+        CKO_DATA,
+        pkcs11Options.attestation,
+      );
+      if (attestationHandle) {
+        const attestationValue = readPkcs11Attribute(pkcs11, session, attestationHandle);
+        hardwareMetadata.attestation = {
+          format: pkcs11Options.attestation.format ?? 'yubihsm-attestation',
+          data: attestationValue.toString('base64'),
+        };
+      }
+    }
+
+    bundle.hardware = hardwareMetadata;
+    return bundle;
+  } finally {
+    if (session !== undefined) {
+      try {
+        if (loggedIn) {
+          pkcs11.C_Logout(session);
+        }
+      } catch (error) {
+        // Ignore logout errors to prioritize primary failure reasons.
+      }
+      try {
+        pkcs11.C_CloseSession(session);
+      } catch (error) {
+        // Ignore close session errors.
+      }
+    }
+    try {
+      pkcs11.C_Finalize();
+    } catch (error) {
+      // Ignore finalize errors.
+    }
+  }
 };
 
 export const signManifestWithSecuritySigner = (
   manifest: Manifest,
   options: SecuritySignerOptions = {},
 ): ManifestSignatureBundle => {
-  const credentials = resolveCredentials(options);
   const digest = computeManifestDigest(manifest);
   const manifestLedger = (manifest as ManifestLedgerMetadata).ledger;
   const ledgerSource =
@@ -213,32 +622,31 @@ export const signManifestWithSecuritySigner = (
   const previousLedgerRoot =
     ledgerSource?.previousRoot ?? manifestLedger?.previousRoot ?? null;
 
-  const x509 = new X509Certificate(credentials.certificatePem);
-  const header = {
-    alg: 'EdDSA',
-    typ: 'SOIManifest',
-    x5c: [x509.raw.toString('base64')],
-  };
-  const payload = {
-    digest: digest.hash,
-    algorithm: digest.algorithm,
+  if (options.pkcs11) {
+    return signManifestWithPkcs11(digest, ledgerRoot, previousLedgerRoot, options);
+  }
+
+  const credentials = resolveCredentials(options);
+  const { signingInput } = buildSigningPreparation(
+    credentials.certificatePem,
+    digest,
     ledgerRoot,
     previousLedgerRoot,
-  };
+  );
+  const signatureBuffer = signData(
+    null,
+    Buffer.from(signingInput, 'utf8'),
+    credentials.privateKeyPem,
+  );
 
-  const encodedHeader = base64UrlEncode(JSON.stringify(header));
-  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
-  const signingInput = `${encodedHeader}.${encodedPayload}`;
-  const signatureBuffer = signData(null, Buffer.from(signingInput, 'utf8'), credentials.privateKeyPem);
-  const encodedSignature = base64UrlEncode(signatureBuffer);
-
-  return {
-    signature: `${signingInput}.${encodedSignature}`,
-    certificate: credentials.certificatePem.trim(),
-    manifestDigest: digest,
+  return buildBundleFromSignature(
+    credentials.certificatePem,
+    digest,
     ledgerRoot,
     previousLedgerRoot,
-  };
+    signingInput,
+    signatureBuffer,
+  );
 };
 
 export const verifyManifestSignatureWithSecuritySigner = (

--- a/packages/report/src/complianceReport.html.ts
+++ b/packages/report/src/complianceReport.html.ts
@@ -1,5 +1,43 @@
 import type { CoverageMetric, CoverageReport } from '@soipack/adapters';
 
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatDateTime = (value?: string): string => {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return escapeHtml(value);
+  }
+  const [isoDate, isoTime] = date.toISOString().split('T');
+  return `${isoDate} ${isoTime.slice(0, 5)} UTC`;
+};
+
+const formatFileSize = (size?: number): string => {
+  if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
+    return '—';
+  }
+  const kiloBytes = size / 1024;
+  if (kiloBytes >= 1024) {
+    return `${(kiloBytes / 1024).toFixed(1)} MB`;
+  }
+  return `${kiloBytes.toFixed(1)} KB`;
+};
+
+const renderLink = (label: string, url?: string): string => {
+  if (!url) {
+    return escapeHtml(label);
+  }
+  return `<a href="${escapeHtml(url)}" target="_blank" rel="noreferrer">${escapeHtml(label)}</a>`;
+};
+
 const formatMetric = (metric: CoverageMetric | undefined): string => {
   if (!metric) {
     return '—';
@@ -86,4 +124,171 @@ export const renderCoverageSummarySection = ({
     ${totalsTable}
     ${fileTable}
   </section>${warningsSection}`;
+};
+
+export interface ChangeRequestBacklogItem {
+  key: string;
+  summary: string;
+  status: string;
+  statusCategory?: string;
+  assignee?: string | null;
+  updatedAt?: string;
+  priority?: string | null;
+  url?: string;
+  transitions?: Array<{ id: string; name: string; toStatus: string; category?: string }>;
+  attachments?: Array<{ id: string; filename: string; url?: string; size?: number; createdAt?: string }>;
+}
+
+export interface ChangeRequestBacklogSectionContext {
+  items: ChangeRequestBacklogItem[];
+}
+
+const renderTransitionSummary = (
+  transitions: ChangeRequestBacklogItem['transitions'],
+): string => {
+  if (!transitions || transitions.length === 0) {
+    return '';
+  }
+  const summary = transitions
+    .map((transition) => `${escapeHtml(transition.name)} → ${escapeHtml(transition.toStatus)}`)
+    .join(', ');
+  return `<div class="cell-description"><strong>Geçişler:</strong> ${summary}</div>`;
+};
+
+const renderAttachmentSummary = (
+  attachments: ChangeRequestBacklogItem['attachments'],
+): string => {
+  if (!attachments || attachments.length === 0) {
+    return '';
+  }
+  const summary = attachments
+    .map((attachment) => {
+      const sizeLabel = attachment.size ? ` (${formatFileSize(attachment.size)})` : '';
+      return renderLink(`${attachment.filename}${sizeLabel}`, attachment.url);
+    })
+    .join('<br />');
+  return `<div class="cell-description"><strong>Ekler:</strong> ${summary}</div>`;
+};
+
+export const renderChangeRequestBacklogSection = ({
+  items,
+}: ChangeRequestBacklogSectionContext): string => {
+  if (!items || items.length === 0) {
+    return '';
+  }
+
+  const rows = items
+    .map((item) => {
+      const keyCell = renderLink(item.key, item.url);
+      const statusLabel = item.statusCategory
+        ? `${escapeHtml(item.status)} <span class="muted">(${escapeHtml(item.statusCategory)})</span>`
+        : escapeHtml(item.status);
+      const assignee = item.assignee ? escapeHtml(item.assignee) : '<span class="muted">Atanmamış</span>';
+      const priority = item.priority ? escapeHtml(item.priority) : '—';
+      const updatedAt = formatDateTime(item.updatedAt);
+
+      return `<tr>
+          <th scope="row">${keyCell}</th>
+          <td>
+            <div class="cell-title">${escapeHtml(item.summary)}</div>
+            ${renderTransitionSummary(item.transitions)}
+            ${renderAttachmentSummary(item.attachments)}
+          </td>
+          <td>${statusLabel}</td>
+          <td>${assignee}</td>
+          <td>${priority}</td>
+          <td>${updatedAt}</td>
+        </tr>`;
+    })
+    .join('');
+
+  return `<section class="section" aria-labelledby="change-request-backlog">
+    <h2 id="change-request-backlog">Değişiklik Talepleri Birikimi</h2>
+    <p class="section-lead">
+      DO-178C uyumluluğu için takip edilen değişiklik taleplerinin durumunu gösterir.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Talep</th>
+          <th scope="col">Özet</th>
+          <th scope="col">Durum</th>
+          <th scope="col">Atanan</th>
+          <th scope="col">Öncelik</th>
+          <th scope="col">Güncellendi</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </section>`;
+};
+
+export interface LedgerAttestationDiffItem {
+  snapshotId: string;
+  ledgerRoot: string;
+  attestedAt: string;
+  manifestDigest?: string;
+  previousLedgerRoot?: string | null;
+  addedEvidence?: string[];
+  removedEvidence?: string[];
+}
+
+export interface LedgerAttestationDiffSectionContext {
+  diffs: LedgerAttestationDiffItem[];
+}
+
+const formatEvidenceList = (values?: string[]): string => {
+  if (!values || values.length === 0) {
+    return '<span class="muted">Yok</span>';
+  }
+  return values.map((value) => `<span class="badge badge-soft">${escapeHtml(value)}</span>`).join(' ');
+};
+
+export const renderLedgerDiffSection = ({ diffs }: LedgerAttestationDiffSectionContext): string => {
+  if (!diffs || diffs.length === 0) {
+    return '';
+  }
+
+  const rows = diffs
+    .map((diff) => {
+      const manifestLine = diff.manifestDigest
+        ? `<div class="muted">Manifest: ${escapeHtml(diff.manifestDigest)}</div>`
+        : '';
+      const previousLine = diff.previousLedgerRoot
+        ? `<div class="muted">Önceki kök: ${escapeHtml(diff.previousLedgerRoot)}</div>`
+        : '';
+
+      return `<tr>
+          <th scope="row">${escapeHtml(diff.snapshotId)}</th>
+          <td>
+            <div class="cell-title">${escapeHtml(diff.ledgerRoot)}</div>
+            ${manifestLine}
+            ${previousLine}
+          </td>
+          <td>${formatDateTime(diff.attestedAt)}</td>
+          <td>
+            <div class="cell-description"><strong>Eklenen:</strong> ${formatEvidenceList(diff.addedEvidence)}</div>
+            <div class="cell-description"><strong>Çıkarılan:</strong> ${formatEvidenceList(diff.removedEvidence)}</div>
+          </td>
+        </tr>`;
+    })
+    .join('');
+
+  return `<section class="section" aria-labelledby="ledger-attestations">
+    <h2 id="ledger-attestations">Ledger Attestasyon Özeti</h2>
+    <p class="section-lead">
+      Kanıt defteri mutabakatı sırasında eklenen ve kaldırılan kanıt girişlerini gösterir.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Snapshot</th>
+          <th scope="col">Ledger Kökü</th>
+          <th scope="col">Attestasyon</th>
+          <th scope="col">Değişiklikler</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </section>`;
 };

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: SOIPack REST API
   version: 0.1.0
@@ -461,14 +461,12 @@ components:
         - type: object
           properties:
             result:
-              oneOf:
-                - type: object
-                  additionalProperties: true
-                - type: 'null'
+              type: object
+              additionalProperties: true
+              nullable: true
             error:
-              oneOf:
-                - $ref: '#/components/schemas/JobError'
-                - type: 'null'
+              $ref: '#/components/schemas/JobError'
+              nullable: true
     JobListResponse:
       type: object
       required:
@@ -872,10 +870,9 @@ components:
           items:
             type: string
         expiresAt:
-          oneOf:
-            - type: string
-            - type: number
-            - type: 'null'
+          type: string
+          format: date-time
+          nullable: true
     AdminApiKeyUpdateRequest:
       type: object
       required:
@@ -896,10 +893,9 @@ components:
           items:
             type: string
         expiresAt:
-          oneOf:
-            - type: string
-            - type: number
-            - type: 'null'
+          type: string
+          format: date-time
+          nullable: true
     WorkspaceRequirement:
       type: object
       required: [id, title, status, tags]
@@ -1037,6 +1033,30 @@ components:
         updatedAt:
           type: string
           format: date-time
+    WorkspaceDocumentThreadResponse:
+      type: object
+      required:
+        - document
+        - comments
+        - signoffs
+        - nextCursor
+      properties:
+        document:
+          $ref: '#/components/schemas/WorkspaceDocument'
+        comments:
+          type: array
+          description: Belgenin en eski tarihten yeni tarihe sıralanmış yorumları.
+          items:
+            $ref: '#/components/schemas/WorkspaceComment'
+        signoffs:
+          type: array
+          description: Revizyonlara ait imza isteği geçmişi (ilk isteğe göre sıralı).
+          items:
+            $ref: '#/components/schemas/WorkspaceSignoff'
+        nextCursor:
+          type: string
+          nullable: true
+          description: Sonraki yorum sayfası için imleç. Daha fazla kayıt yoksa null döner.
     WorkspaceDocumentUpdateRequest:
       type: object
       required: [kind, title, content]
@@ -1447,6 +1467,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /v1/workspaces/{workspaceId}/documents/{documentId}:
+    get:
+      operationId: getWorkspaceDocumentThread
+      summary: Çalışma alanı belgesinin son revizyonunu, yorumlarını ve imza geçmişini getirir.
+      tags:
+        - Workspaces
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: workspaceId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/LicenseHeader'
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Yorumları sayfalarken kullanılacak imleç. Bir önceki yanıttaki `nextCursor` değerini iletin.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Aynı yanıtta döndürülecek azami yorum sayısı. Varsayılan 20'dir.
+      responses:
+        '200':
+          description: Belge ve etkinlikleri başarıyla getirildi.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceDocumentThreadResponse'
+        '400':
+          description: Sorgu parametreleri geçersiz.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Kullanıcının yeterli rolü yok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Belge bulunamadı.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     put:
       operationId: updateWorkspaceDocument
       summary: Çalışma alanı belgesini oluşturur veya günceller.

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -486,7 +486,7 @@ export const createJwtPrincipalResolver = (
     }
 
     const roles = await loader.loadRoles(context.tenantId, user.id);
-    const uniqueRoles = roles.length > 0 ? Array.from(new Set<UserRole>(roles)) : [DEFAULT_ROLE];
+    const uniqueRoles = roles.length > 0 ? Array.from(new Set<UserRole>(roles)) : [];
     const permissions = computeJwtPermissions(uniqueRoles);
 
     return {

--- a/packages/server/src/workspaces/service.test.ts
+++ b/packages/server/src/workspaces/service.test.ts
@@ -169,4 +169,113 @@ describe('WorkspaceService', () => {
       }),
     ).rejects.toBeInstanceOf(WorkspaceRevisionNotFoundError);
   });
+
+  it('returns document threads with empty activity lists for new documents', async () => {
+    const document = await service.saveRevision(baseInput);
+
+    const thread = await service.getDocumentThread(
+      baseInput.tenantId,
+      baseInput.workspaceId,
+      baseInput.documentId,
+    );
+
+    expect(thread).toBeDefined();
+    expect(thread?.document.latestRevision.id).toBe(document.latestRevision.id);
+    expect(thread?.comments).toEqual([]);
+    expect(thread?.signoffs).toEqual([]);
+    expect(thread?.nextCursor).toBeNull();
+  });
+
+  it('paginates document comments in chronological order', async () => {
+    const document = await service.saveRevision(baseInput);
+
+    const commentBodies = ['First comment', 'Second comment', 'Third comment'];
+    for (const body of commentBodies) {
+      await service.addComment({
+        tenantId: baseInput.tenantId,
+        workspaceId: baseInput.workspaceId,
+        documentId: baseInput.documentId,
+        authorId: 'commenter',
+        body,
+        revisionId: document.latestRevision.id,
+      });
+    }
+
+    const firstPage = await service.getDocumentThread(
+      baseInput.tenantId,
+      baseInput.workspaceId,
+      baseInput.documentId,
+      { limit: 2 },
+    );
+
+    expect(firstPage).toBeDefined();
+    expect(firstPage?.comments.map((entry) => entry.body)).toEqual(['First comment', 'Second comment']);
+    expect(firstPage?.nextCursor).toBeTruthy();
+
+    const secondPage = await service.listDocumentActivity(
+      baseInput.tenantId,
+      baseInput.workspaceId,
+      baseInput.documentId,
+      { limit: 2, cursor: firstPage?.nextCursor ?? undefined },
+    );
+
+    expect(secondPage.comments.map((entry) => entry.body)).toEqual(['Third comment']);
+    expect(secondPage.nextCursor).toBeNull();
+    expect(secondPage.signoffs).toEqual([]);
+  });
+
+  it('returns signoff history with mixed approval states', async () => {
+    const document = await service.saveRevision(baseInput);
+
+    await service.requestSignoff({
+      tenantId: baseInput.tenantId,
+      workspaceId: baseInput.workspaceId,
+      documentId: baseInput.documentId,
+      revisionHash: document.latestRevision.hash,
+      requestedBy: 'maintainer-1',
+      requestedFor: 'approver-1',
+    });
+
+    const secondSignoff = await service.requestSignoff({
+      tenantId: baseInput.tenantId,
+      workspaceId: baseInput.workspaceId,
+      documentId: baseInput.documentId,
+      revisionHash: document.latestRevision.hash,
+      requestedBy: 'maintainer-1',
+      requestedFor: 'approver-2',
+    });
+
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const signedAt = new Date().toISOString();
+    const payload = Buffer.from(
+      `${baseInput.tenantId}:${baseInput.workspaceId}:${baseInput.documentId}:${document.latestRevision.hash}:${signedAt}`,
+      'utf8',
+    );
+    const signature = signMessage(null, payload, privateKey);
+    const exported = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+    const rawPublicKey = exported.slice(exported.length - 32);
+
+    await service.approveSignoff({
+      tenantId: baseInput.tenantId,
+      workspaceId: baseInput.workspaceId,
+      signoffId: secondSignoff.id,
+      actorId: 'approver-2',
+      expectedRevisionHash: document.latestRevision.hash,
+      publicKey: rawPublicKey.toString('base64'),
+      signature: signature.toString('base64'),
+      signedAt,
+    });
+
+    const thread = await service.getDocumentThread(
+      baseInput.tenantId,
+      baseInput.workspaceId,
+      baseInput.documentId,
+    );
+
+    expect(thread).toBeDefined();
+    expect(thread?.signoffs.map((entry) => entry.status)).toEqual(['pending', 'approved']);
+    const approved = thread?.signoffs.find((entry) => entry.status === 'approved');
+    expect(approved?.signerId).toBe('approver-2');
+    expect(approved?.signature).toBe(signature.toString('base64'));
+  });
 });

--- a/packages/server/tsconfig.test.json
+++ b/packages/server/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "ambient"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/ui/src/components/NavigationTabs.tsx
+++ b/packages/ui/src/components/NavigationTabs.tsx
@@ -1,11 +1,19 @@
 import type { JSX } from 'react';
 
-export type View = 'upload' | 'compliance' | 'traceability' | 'risk' | 'timeline';
+export type View =
+  | 'upload'
+  | 'compliance'
+  | 'traceability'
+  | 'risk'
+  | 'timeline'
+  | 'requirements'
+  | 'adminUsers';
 
 interface NavigationTabsProps {
   activeView: View;
   onChange: (view: View) => void;
   disabled: boolean;
+  views?: View[];
 }
 
 const viewLabels: Record<View, string> = {
@@ -13,7 +21,9 @@ const viewLabels: Record<View, string> = {
   compliance: 'Uyum Matrisi',
   traceability: 'İzlenebilirlik',
   risk: 'Risk Kokpiti',
-  timeline: 'Zaman Çizelgesi'
+  timeline: 'Zaman Çizelgesi',
+  requirements: 'Gereksinim Editörü',
+  adminUsers: 'Yönetici Kullanıcılar',
 };
 
 const viewIcons: Record<View, JSX.Element> = {
@@ -45,13 +55,32 @@ const viewIcons: Record<View, JSX.Element> = {
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="h-5 w-5">
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 12h18M12 3v18m6-11.25l-3 3 3 3m-12-6l3 3-3 3" />
     </svg>
-  )
+  ),
+  requirements: (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="h-5 w-5">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 13.5l3 3 4.5-6m-4.5-6.75L5.25 6a2.25 2.25 0 00-1.5 2.121V18A2.25 2.25 0 006 20.25h12A2.25 2.25 0 0020.25 18V8.121A2.25 2.25 0 0018.75 6L12 3.75z"
+      />
+    </svg>
+  ),
+  adminUsers: (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="h-5 w-5">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M7.5 7.5A2.25 2.25 0 0110.5 9.75c0 1.243-1.007 2.25-2.25 2.25S6 10.993 6 9.75 7.007 7.5 8.25 7.5zM15.75 8.25a2.25 2.25 0 110 4.5 2.25 2.25 0 010-4.5zM4.5 18a3.75 3.75 0 017.5 0m0 0h3a3.75 3.75 0 017.5 0"
+      />
+    </svg>
+  ),
 };
 
-export function NavigationTabs({ activeView, onChange, disabled }: NavigationTabsProps) {
+export function NavigationTabs({ activeView, onChange, disabled, views }: NavigationTabsProps) {
+  const availableViews = views ?? (Object.keys(viewLabels) as View[]);
   return (
     <div className="flex flex-wrap gap-2 rounded-2xl border border-slate-800 bg-slate-900/70 p-2 text-sm text-slate-300 shadow-lg shadow-slate-950/30 backdrop-blur">
-      {(Object.keys(viewLabels) as View[]).map((view) => {
+      {availableViews.map((view) => {
         const isActive = activeView === view;
         return (
           <button

--- a/packages/ui/src/pages/AdminUsersPage.test.tsx
+++ b/packages/ui/src/pages/AdminUsersPage.test.tsx
@@ -1,0 +1,186 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AdminUsersPage from './AdminUsersPage';
+import {
+  ApiError,
+  createAdminUser,
+  deleteAdminUser,
+  listAdminRoles,
+  listAdminUsers,
+  updateAdminUser,
+  type AdminRole,
+  type AdminUser,
+} from '../services/api';
+
+jest.mock('../services/api', () => {
+  const actual = jest.requireActual('../services/api');
+  return {
+    ...actual,
+    listAdminRoles: jest.fn(),
+    listAdminUsers: jest.fn(),
+    createAdminUser: jest.fn(),
+    updateAdminUser: jest.fn(),
+    deleteAdminUser: jest.fn(),
+  };
+});
+
+describe('AdminUsersPage', () => {
+  const mockListRoles = listAdminRoles as jest.MockedFunction<typeof listAdminRoles>;
+  const mockListUsers = listAdminUsers as jest.MockedFunction<typeof listAdminUsers>;
+  const mockCreateUser = createAdminUser as jest.MockedFunction<typeof createAdminUser>;
+  const mockUpdateUser = updateAdminUser as jest.MockedFunction<typeof updateAdminUser>;
+  const mockDeleteUser = deleteAdminUser as jest.MockedFunction<typeof deleteAdminUser>;
+
+  const baseRoles: AdminRole[] = [
+    { name: 'admin', permissions: [], description: 'Tam yetki' },
+    { name: 'operator', permissions: [], description: 'Güncelleme yetkisi' },
+  ];
+
+  const baseUsers: AdminUser[] = [
+    {
+      id: 'user-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      roles: ['admin'],
+      status: 'active',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListRoles.mockResolvedValue({ roles: baseRoles });
+    mockListUsers.mockResolvedValue({ users: baseUsers });
+  });
+
+  it('renders users and supports create, edit and secret reset flows', async () => {
+    mockCreateUser.mockResolvedValue({
+      user: {
+        id: 'user-2',
+        email: 'bob@example.com',
+        displayName: 'Bob',
+        roles: ['operator'],
+        status: 'invited',
+      },
+      secret: 'temporary-secret',
+    });
+
+    mockUpdateUser.mockResolvedValue({
+      user: {
+        ...baseUsers[0],
+        displayName: 'Alice Updated',
+        roles: ['operator'],
+      },
+    });
+
+    mockDeleteUser.mockResolvedValue(undefined);
+
+    render(<AdminUsersPage token="token" license="license" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    });
+
+    const table = screen.getByTestId('admin-users-table');
+    expect(table).toBeInTheDocument();
+    expect(table.textContent).toContain('Alice');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Yeni Kullanıcı' }));
+
+    const emailInput = await screen.findByLabelText('E-posta');
+    await user.type(emailInput, 'bob@example.com');
+    const displayNameInput = screen.getByLabelText('Görünen ad');
+    await user.type(displayNameInput, 'Bob');
+
+    const roleSelect = screen.getByLabelText('Roller');
+    await user.selectOptions(roleSelect, ['operator']);
+
+    await user.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    await waitFor(() => {
+      expect(mockCreateUser).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'bob@example.com', roles: ['operator'] }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('temporary-secret')).toBeInTheDocument();
+      expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+    });
+
+    const editButtons = screen.getAllByRole('button', { name: /Düzenle/ });
+    await user.click(editButtons[0]);
+
+    const updatedDisplayName = screen.getByLabelText('Görünen ad');
+    fireEvent.change(updatedDisplayName, { target: { value: 'Alice Updated' } });
+    const updatedRoles = screen.getByLabelText('Roller');
+    await user.selectOptions(updatedRoles, ['operator']);
+
+    mockUpdateUser.mockResolvedValueOnce({
+      user: {
+        ...baseUsers[0],
+        displayName: 'Alice Updated',
+        roles: ['operator'],
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', roles: ['operator'] }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Alice Updated').length).toBeGreaterThan(0);
+    });
+
+    mockUpdateUser.mockResolvedValueOnce({
+      user: {
+        ...baseUsers[0],
+        roles: ['admin'],
+      },
+      secret: 'rotated-secret',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Sır Sıfırla' }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', rotateSecret: true }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('rotated-secret')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Sil' }));
+    await waitFor(() => {
+      expect(mockDeleteUser).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1' }),
+      );
+    });
+  });
+
+  it('surfaces validation errors from the server', async () => {
+    mockCreateUser.mockRejectedValue(new ApiError(422, 'ROLE_REQUIRED'));
+
+    render(<AdminUsersPage token="token" license="license" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Yeni Kullanıcı' }));
+    await user.type(await screen.findByLabelText('E-posta'), 'bob@example.com');
+    await user.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ROLE_REQUIRED')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/AdminUsersPage.tsx
+++ b/packages/ui/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,300 @@
+import { Alert, Button, Input, PageHeader } from '@bora/ui-kit';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+
+import {
+  ApiError,
+  createAdminUser,
+  deleteAdminUser,
+  listAdminRoles,
+  listAdminUsers,
+  updateAdminUser,
+  type AdminRole,
+  type AdminUser,
+} from '../services/api';
+
+interface AdminUsersPageProps {
+  token?: string;
+  license?: string;
+}
+
+interface AdminUserFormState {
+  email: string;
+  displayName: string;
+  roles: string[];
+}
+
+const emptyForm: AdminUserFormState = { email: '', displayName: '', roles: [] };
+
+export default function AdminUsersPage({ token = '', license = '' }: AdminUsersPageProps) {
+  const trimmedToken = token.trim();
+  const trimmedLicense = license.trim();
+  const credentials = useMemo(() => ({ token: trimmedToken, license: trimmedLicense }), [trimmedToken, trimmedLicense]);
+
+  const [roles, setRoles] = useState<AdminRole[]>([]);
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [dialogMode, setDialogMode] = useState<'create' | 'edit' | null>(null);
+  const [form, setForm] = useState<AdminUserFormState>(emptyForm);
+  const [editingUserId, setEditingUserId] = useState<string | null>(null);
+  const [secretNotice, setSecretNotice] = useState<{ type: 'success' | 'warning'; message: string } | null>(null);
+
+  useEffect(() => {
+    if (!trimmedToken || !trimmedLicense) {
+      setRoles([]);
+      setUsers([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    const auth = { token: trimmedToken, license: trimmedLicense, signal: controller.signal } as const;
+
+    Promise.all([listAdminRoles(auth), listAdminUsers(auth)])
+      .then(([roleResponse, userResponse]) => {
+        setRoles(roleResponse.roles);
+        setUsers(userResponse.users);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof ApiError ? err.message : 'Yönetici kullanıcıları yüklenemedi.');
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [trimmedToken, trimmedLicense]);
+
+  const resetDialog = () => {
+    setDialogMode(null);
+    setForm(emptyForm);
+    setEditingUserId(null);
+    setSubmitError(null);
+  };
+
+  const handleOpenCreate = () => {
+    setSecretNotice(null);
+    setDialogMode('create');
+    setForm(emptyForm);
+    setEditingUserId(null);
+  };
+
+  const handleOpenEdit = (user: AdminUser) => {
+    setSecretNotice(null);
+    setDialogMode('edit');
+    setEditingUserId(user.id);
+    setForm({
+      email: user.email,
+      displayName: user.displayName ?? '',
+      roles: user.roles ?? [],
+    });
+  };
+
+  const handleFormChange = (field: keyof AdminUserFormState, value: string | string[]) => {
+    setForm((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!dialogMode || !trimmedToken || !trimmedLicense) {
+      return;
+    }
+    setSubmitError(null);
+
+    const payload = {
+      token: credentials.token,
+      license: credentials.license,
+      email: form.email.trim(),
+      roles: form.roles,
+      displayName: form.displayName.trim() || null,
+    } as const;
+
+    try {
+      if (dialogMode === 'create') {
+        const response = await createAdminUser(payload);
+        setUsers((prev) => [...prev.filter((user) => user.id !== response.user.id), response.user]);
+        if (response.secret) {
+          setSecretNotice({ type: 'success', message: `Yeni kullanıcı parolası: ${response.secret}` });
+        }
+      } else if (dialogMode === 'edit' && editingUserId) {
+        const response = await updateAdminUser({ ...payload, userId: editingUserId });
+        setUsers((prev) => prev.map((user) => (user.id === response.user.id ? response.user : user)));
+        if (response.secret) {
+          setSecretNotice({ type: 'success', message: `Yeni oturum sırrı: ${response.secret}` });
+        }
+      }
+      resetDialog();
+    } catch (err) {
+      setSubmitError(err instanceof ApiError ? err.message : 'Kullanıcı kaydedilemedi.');
+    }
+  };
+
+  const handleRotateSecret = async (user: AdminUser) => {
+    if (!trimmedToken || !trimmedLicense) {
+      return;
+    }
+    setSecretNotice(null);
+    try {
+      const response = await updateAdminUser({
+        token: credentials.token,
+        license: credentials.license,
+        userId: user.id,
+        email: user.email,
+        roles: user.roles ?? [],
+        rotateSecret: true,
+      });
+      setUsers((prev) => prev.map((entry) => (entry.id === response.user.id ? response.user : entry)));
+      if (response.secret) {
+        setSecretNotice({ type: 'success', message: `Yeni oturum sırrı: ${response.secret}` });
+      }
+    } catch (err) {
+      setSecretNotice({
+        type: 'warning',
+        message: err instanceof ApiError ? err.message : 'Sır yeniden oluşturulamadı.',
+      });
+    }
+  };
+
+  const handleDelete = async (user: AdminUser) => {
+    if (!trimmedToken || !trimmedLicense) {
+      return;
+    }
+    await deleteAdminUser({ token: credentials.token, license: credentials.license, userId: user.id });
+    setUsers((prev) => prev.filter((entry) => entry.id !== user.id));
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="RBAC Kullanıcı Yönetimi"
+        description="Yönetici rollerini ve güvenlik bilgilerini güncelleyin."
+        breadcrumb={[
+          { label: 'Dashboard', href: '/' },
+          { label: 'RBAC', href: '/admin' },
+          { label: 'Kullanıcılar' },
+        ]}
+      />
+
+      {error && <Alert variant="destructive" title="Yükleme başarısız" description={error} />}
+      {secretNotice?.type === 'success' && (
+        <Alert title="Güncelleme tamamlandı" description={secretNotice.message} />
+      )}
+      {secretNotice?.type === 'warning' && (
+        <Alert variant="warning" title="Uyarı" description={secretNotice.message} />
+      )}
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">Kullanıcılar</h2>
+        <Button onClick={handleOpenCreate} disabled={loading}>Yeni Kullanıcı</Button>
+      </div>
+
+      {loading ? (
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 text-center text-slate-300">Veriler yükleniyor…</div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/60">
+          <table className="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-200" data-testid="admin-users-table">
+            <thead className="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+              <tr>
+                <th className="px-4 py-3">E-posta</th>
+                <th className="px-4 py-3">Görünen Ad</th>
+                <th className="px-4 py-3">Roller</th>
+                <th className="px-4 py-3">Durum</th>
+                <th className="px-4 py-3 text-right">İşlemler</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td className="px-4 py-3 font-mono text-slate-100">{user.email}</td>
+                  <td className="px-4 py-3">{user.displayName ?? '—'}</td>
+                  <td className="px-4 py-3">{(user.roles ?? []).join(', ') || '—'}</td>
+                  <td className="px-4 py-3 capitalize">{user.status ?? 'unknown'}</td>
+                  <td className="px-4 py-3 text-right space-x-2">
+                    <Button size="sm" variant="ghost" onClick={() => handleOpenEdit(user)}>
+                      Düzenle
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => handleRotateSecret(user)}>
+                      Sır Sıfırla
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => handleDelete(user)}>
+                      Sil
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {users.length === 0 && (
+                <tr>
+                  <td className="px-4 py-5 text-center text-slate-500" colSpan={5}>
+                    Henüz tanımlı kullanıcı yok.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {dialogMode && (
+        <div role="dialog" aria-modal="true" className="rounded-3xl border border-slate-800 bg-slate-900/90 p-6 shadow-xl">
+          <h3 className="text-lg font-semibold text-white">
+            {dialogMode === 'create' ? 'Yeni Kullanıcı Oluştur' : 'Kullanıcıyı Düzenle'}
+          </h3>
+          <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+            <label className="block text-sm text-slate-300">
+              <span className="mb-1 block font-medium">E-posta</span>
+              <Input
+                value={form.email}
+                onChange={(event) => handleFormChange('email', event.target.value)}
+                required
+                type="email"
+              />
+            </label>
+            <label className="block text-sm text-slate-300">
+              <span className="mb-1 block font-medium">Görünen ad</span>
+              <Input value={form.displayName} onChange={(event) => handleFormChange('displayName', event.target.value)} />
+            </label>
+            <label className="block text-sm text-slate-300">
+              <span className="mb-1 block font-medium">Roller</span>
+              <select
+                multiple
+                className="w-full rounded-xl border border-slate-700 bg-slate-950/70 p-2"
+                value={form.roles}
+                onChange={(event) => {
+                  const selected = Array.from(event.target.selectedOptions).map((option) => option.value);
+                  handleFormChange('roles', selected);
+                }}
+              >
+                {roles.map((role) => (
+                  <option key={role.name} value={role.name}>
+                    {role.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {submitError && <Alert variant="destructive" title="Kaydedilemedi" description={submitError} />}
+
+            <div className="flex items-center justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={resetDialog}>
+                Vazgeç
+              </Button>
+              <Button type="submit">Kaydet</Button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/pages/RequirementsEditorPage.test.tsx
+++ b/packages/ui/src/pages/RequirementsEditorPage.test.tsx
@@ -1,0 +1,251 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import RequirementsEditorPage, { type RequirementRecord } from './RequirementsEditorPage';
+import {
+  createWorkspaceComment,
+  getWorkspaceDocumentThread,
+  requestWorkspaceSignoff,
+  updateWorkspaceDocument,
+  type WorkspaceComment,
+  type WorkspaceDocument,
+  type WorkspaceSignoff,
+} from '../services/api';
+
+jest.mock('../services/api', () => {
+  const actual = jest.requireActual('../services/api');
+  return {
+    ...actual,
+    getWorkspaceDocumentThread: jest.fn(),
+    updateWorkspaceDocument: jest.fn(),
+    createWorkspaceComment: jest.fn(),
+    requestWorkspaceSignoff: jest.fn(),
+  };
+});
+
+describe('RequirementsEditorPage', () => {
+  const mockGetThread = getWorkspaceDocumentThread as jest.MockedFunction<typeof getWorkspaceDocumentThread>;
+  const mockUpdateDocument = updateWorkspaceDocument as jest.MockedFunction<typeof updateWorkspaceDocument>;
+  const mockCreateComment = createWorkspaceComment as jest.MockedFunction<typeof createWorkspaceComment>;
+  const mockRequestSignoff = requestWorkspaceSignoff as jest.MockedFunction<typeof requestWorkspaceSignoff>;
+
+  const baseDocument: WorkspaceDocument<RequirementRecord[]> = {
+    id: 'requirements',
+    tenantId: 'tenant-1',
+    workspaceId: 'ws-1',
+    kind: 'requirements',
+    title: 'Flight Controls',
+    createdAt: '2024-03-01T00:00:00.000Z',
+    updatedAt: '2024-03-01T00:00:00.000Z',
+    revision: {
+      id: 'rev-1',
+      number: 1,
+      hash: 'abc123',
+      authorId: 'alice',
+      createdAt: '2024-03-01T00:00:00.000Z',
+      content: [
+        {
+          id: 'REQ-1',
+          title: 'Autopilot shall disengage on manual override.',
+          description: 'Ensure manual override has priority.',
+          status: 'draft',
+          tags: ['safety'],
+        },
+      ],
+    },
+  };
+
+  const baseComments: WorkspaceComment[] = [
+    {
+      id: 'comment-1',
+      documentId: 'requirements',
+      revisionId: 'rev-1',
+      tenantId: 'tenant-1',
+      workspaceId: 'ws-1',
+      authorId: 'qa-lead',
+      body: 'Please attach verification evidence.',
+      createdAt: '2024-03-01T10:00:00.000Z',
+    },
+  ];
+
+  const baseSignoffs: WorkspaceSignoff[] = [
+    {
+      id: 'signoff-1',
+      documentId: 'requirements',
+      revisionId: 'rev-1',
+      tenantId: 'tenant-1',
+      workspaceId: 'ws-1',
+      revisionHash: 'abc123',
+      status: 'pending',
+      requestedBy: 'alice',
+      requestedFor: 'qa',
+      createdAt: '2024-03-02T08:00:00.000Z',
+      updatedAt: '2024-03-02T08:00:00.000Z',
+      approvedAt: null,
+      rejectedAt: null,
+    },
+  ];
+
+  const renderPage = () =>
+    render(
+      <RequirementsEditorPage
+        token="token"
+        license="license"
+        workspaceId="ws-1"
+        documentId="requirements"
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders requirements, comments and signoffs from the thread', async () => {
+    mockGetThread.mockResolvedValue({
+      document: baseDocument,
+      comments: baseComments,
+      signoffs: baseSignoffs,
+      nextCursor: null,
+    } as unknown as Awaited<ReturnType<typeof getWorkspaceDocumentThread>>);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('requirements-grid')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Requirement ID 1')).toHaveValue('REQ-1');
+    expect(screen.getByLabelText('Title 1')).toHaveValue('Autopilot shall disengage on manual override.');
+    expect(screen.getByText(/verification evidence/i)).toBeInTheDocument();
+    expect(screen.getByText(/Requested by alice/i)).toBeInTheDocument();
+  });
+
+  it('saves changes with expected hash and updates the revision summary', async () => {
+    mockGetThread.mockResolvedValue({
+      document: baseDocument,
+      comments: baseComments,
+      signoffs: baseSignoffs,
+      nextCursor: null,
+    } as unknown as Awaited<ReturnType<typeof getWorkspaceDocumentThread>>);
+
+    mockUpdateDocument.mockResolvedValue({
+      document: {
+        ...baseDocument,
+        revision: {
+          ...baseDocument.revision,
+          hash: 'def456',
+          number: 2,
+          content: [
+            {
+              id: 'REQ-1',
+              title: 'Updated title',
+              description: 'Ensure manual override has priority.',
+              status: 'approved',
+              tags: ['safety'],
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof updateWorkspaceDocument>>);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('requirements-grid')).toBeInTheDocument();
+    });
+
+    const titleInput = screen.getByLabelText('Title 1');
+    fireEvent.change(titleInput, { target: { value: 'Updated title' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateDocument).toHaveBeenCalled();
+    });
+
+    const updateCall = mockUpdateDocument.mock.calls[0]?.[0] as
+      | undefined
+      | {
+          expectedHash?: string;
+          content?: Array<{ title?: string }>;
+        };
+    expect(updateCall?.expectedHash).toBe('abc123');
+    expect(updateCall?.content?.[0]?.title).toBe('Updated title');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('revision-hash')).toHaveTextContent('def456');
+    });
+  });
+
+  it('allows posting comments and requesting signoffs', async () => {
+    mockGetThread.mockResolvedValue({
+      document: baseDocument,
+      comments: [],
+      signoffs: [],
+      nextCursor: null,
+    } as unknown as Awaited<ReturnType<typeof getWorkspaceDocumentThread>>);
+
+    mockCreateComment.mockResolvedValue({
+      comment: {
+        id: 'comment-2',
+        documentId: 'requirements',
+        revisionId: 'rev-1',
+        tenantId: 'tenant-1',
+        workspaceId: 'ws-1',
+        authorId: 'alice',
+        body: 'Looks great!',
+        createdAt: '2024-03-01T12:00:00.000Z',
+      },
+    } as Awaited<ReturnType<typeof createWorkspaceComment>>);
+
+    mockRequestSignoff.mockResolvedValue({
+      signoff: {
+        ...baseSignoffs[0],
+        id: 'signoff-2',
+        requestedFor: 'der',
+        revisionHash: 'abc123',
+      },
+    } as Awaited<ReturnType<typeof requestWorkspaceSignoff>>);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('requirements-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Add comment'), { target: { value: 'Looks great!' } });
+    fireEvent.click(screen.getByRole('button', { name: /post comment/i }));
+
+    await waitFor(() => {
+      expect(mockCreateComment).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Looks great!')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /request signoff/i }));
+
+    const targetInput = await screen.findByLabelText('Requested for');
+    fireEvent.change(targetInput, { target: { value: 'der' } });
+    fireEvent.click(screen.getByRole('button', { name: /send request/i }));
+
+    await waitFor(() => {
+      expect(mockRequestSignoff).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentId: 'requirements',
+          requestedFor: 'der',
+          revisionId: 'rev-1',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('der')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/pages/RequirementsEditorPage.tsx
+++ b/packages/ui/src/pages/RequirementsEditorPage.tsx
@@ -1,0 +1,557 @@
+import { Alert, Badge, Button, Input, PageHeader, Skeleton, Textarea } from '@bora/ui-kit';
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  ApiError,
+  createWorkspaceComment,
+  getWorkspaceDocumentThread,
+  requestWorkspaceSignoff,
+  updateWorkspaceDocument,
+  type WorkspaceComment,
+  type WorkspaceDocument,
+  type WorkspaceDocumentThread,
+  type WorkspaceSignoff,
+} from '../services/api';
+
+const requirementStatuses = ['draft', 'approved', 'implemented', 'verified'] as const;
+type RequirementStatus = (typeof requirementStatuses)[number];
+
+export type RequirementRecord = {
+  id: string;
+  title: string;
+  description: string;
+  status: RequirementStatus;
+  tags: string[];
+};
+
+type RequirementsEditorPageProps = {
+  token?: string;
+  license?: string;
+  workspaceId: string;
+  documentId: string;
+  initialThread?: WorkspaceDocumentThread<RequirementRecord[]> | null;
+};
+
+const toLowerHash = (hash?: string | null): string => (hash ?? '').toLowerCase();
+
+const normalizeRequirement = (value: unknown): RequirementRecord => {
+  if (!value || typeof value !== 'object') {
+    return { id: '', title: '', description: '', status: 'draft', tags: [] };
+  }
+  const candidate = value as Partial<RequirementRecord> & { tags?: unknown; status?: unknown };
+  const status = requirementStatuses.includes(candidate.status as RequirementStatus)
+    ? (candidate.status as RequirementStatus)
+    : 'draft';
+  const tags = Array.isArray(candidate.tags)
+    ? (candidate.tags as unknown[])
+        .map((tag) => (typeof tag === 'string' ? tag.trim() : String(tag)))
+        .filter((tag) => tag.length > 0)
+    : [];
+  return {
+    id: typeof candidate.id === 'string' ? candidate.id : '',
+    title: typeof candidate.title === 'string' ? candidate.title : '',
+    description: typeof candidate.description === 'string' ? candidate.description : '',
+    status,
+    tags,
+  };
+};
+
+const normalizeRequirements = (value: unknown): RequirementRecord[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => normalizeRequirement(entry));
+};
+
+const serializeTags = (tags: string[]): string => tags.join(', ');
+
+const parseTags = (value: string): string[] =>
+  value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+
+export default function RequirementsEditorPage({
+  token = '',
+  license = '',
+  workspaceId,
+  documentId,
+  initialThread = null,
+}: RequirementsEditorPageProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [document, setDocument] = useState<WorkspaceDocument<RequirementRecord[]> | null>(null);
+  const [requirements, setRequirements] = useState<RequirementRecord[]>([]);
+  const [comments, setComments] = useState<WorkspaceComment[]>([]);
+  const [signoffs, setSignoffs] = useState<WorkspaceSignoff[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [commentDraft, setCommentDraft] = useState('');
+  const [commentError, setCommentError] = useState<string | null>(null);
+  const [isPostingComment, setIsPostingComment] = useState(false);
+  const [showSignoffModal, setShowSignoffModal] = useState(false);
+  const [signoffTarget, setSignoffTarget] = useState('');
+  const [signoffError, setSignoffError] = useState<string | null>(null);
+  const [isRequestingSignoff, setIsRequestingSignoff] = useState(false);
+
+  const trimmedToken = token.trim();
+  const trimmedLicense = license.trim();
+
+  const hydrateThread = useCallback(
+    (thread: WorkspaceDocumentThread<RequirementRecord[]>) => {
+      const normalizedContent = normalizeRequirements(thread.document.revision.content);
+      const normalizedDocument: WorkspaceDocument<RequirementRecord[]> = {
+        ...thread.document,
+        revision: {
+          ...thread.document.revision,
+          hash: toLowerHash(thread.document.revision?.hash),
+          content: normalizedContent,
+        },
+      };
+      setDocument(normalizedDocument);
+      setRequirements(normalizedContent);
+      setComments(thread.comments);
+      setSignoffs(thread.signoffs.map((entry) => ({ ...entry, revisionHash: toLowerHash(entry.revisionHash) })));
+      setNextCursor(thread.nextCursor);
+      setLoading(false);
+      setError(null);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (initialThread) {
+      hydrateThread(initialThread);
+    }
+  }, [hydrateThread, initialThread]);
+
+  useEffect(() => {
+    if (!trimmedToken || !trimmedLicense) {
+      setLoading(false);
+      setError('Token ve lisans gereklidir.');
+      setDocument(null);
+      setRequirements([]);
+      setComments([]);
+      setSignoffs([]);
+      setNextCursor(null);
+      return;
+    }
+
+    if (initialThread && document) {
+      const expectedHash = toLowerHash(initialThread.document.revision?.hash);
+      if (document.revision.hash === expectedHash) {
+        return;
+      }
+    } else if (initialThread && !document) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getWorkspaceDocumentThread<RequirementRecord[]>({
+      token: trimmedToken,
+      license: trimmedLicense,
+      workspaceId,
+      documentId,
+      signal: controller.signal,
+    })
+      .then((thread) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        hydrateThread(thread);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(err instanceof ApiError ? err.message : 'Belge yüklenemedi.');
+        setLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [trimmedToken, trimmedLicense, workspaceId, documentId, initialThread, document, hydrateThread]);
+
+  const handleRequirementChange = (
+    index: number,
+    field: keyof RequirementRecord,
+    value: string | RequirementStatus,
+  ) => {
+    setRequirements((previous) => {
+      const next = [...previous];
+      const current = { ...next[index] };
+      if (field === 'tags') {
+        current.tags = parseTags(value as string);
+      } else if (field === 'status') {
+        current.status = value as RequirementStatus;
+      } else if (field === 'description') {
+        current.description = value as string;
+      } else if (field === 'id') {
+        current.id = value as string;
+      } else if (field === 'title') {
+        current.title = value as string;
+      }
+      next[index] = current;
+      return next;
+    });
+  };
+
+  const handleAddRequirement = () => {
+    setRequirements((previous) => [
+      ...previous,
+      { id: '', title: '', description: '', status: 'draft', tags: [] },
+    ]);
+  };
+
+  const handleSave = async () => {
+    if (!document || !trimmedToken || !trimmedLicense) {
+      return;
+    }
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const payloadContent = requirements.map((record) => ({
+        id: record.id.trim(),
+        title: record.title.trim(),
+        description: record.description.trim(),
+        status: record.status,
+        tags: record.tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0),
+      }));
+      const response = await updateWorkspaceDocument<RequirementRecord[]>({
+        token: trimmedToken,
+        license: trimmedLicense,
+        workspaceId,
+        documentId,
+        expectedHash: document.revision.hash,
+        title: document.title,
+        content: payloadContent,
+      });
+      const normalizedContent = normalizeRequirements(response.document.revision.content);
+      const normalizedDocument: WorkspaceDocument<RequirementRecord[]> = {
+        ...response.document,
+        revision: {
+          ...response.document.revision,
+          hash: toLowerHash(response.document.revision?.hash),
+          content: normalizedContent,
+        },
+      };
+      setDocument(normalizedDocument);
+      setRequirements(normalizedContent);
+    } catch (err) {
+      setSaveError(err instanceof ApiError ? err.message : 'Belge kaydedilemedi.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSubmitComment = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!document || !trimmedToken || !trimmedLicense) {
+      return;
+    }
+    const trimmed = commentDraft.trim();
+    if (!trimmed) {
+      setCommentError('Yorum metni gereklidir.');
+      return;
+    }
+
+    setIsPostingComment(true);
+    setCommentError(null);
+    try {
+      const response = await createWorkspaceComment({
+        token: trimmedToken,
+        license: trimmedLicense,
+        workspaceId,
+        documentId,
+        revisionId: document.revision.id,
+        body: trimmed,
+      });
+      setComments((previous) => [...previous, response.comment]);
+      setCommentDraft('');
+    } catch (err) {
+      setCommentError(err instanceof ApiError ? err.message : 'Yorum eklenemedi.');
+    } finally {
+      setIsPostingComment(false);
+    }
+  };
+
+  const handleSignoffSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!document || !trimmedToken || !trimmedLicense) {
+      return;
+    }
+    const target = signoffTarget.trim();
+    if (!target) {
+      setSignoffError('İmza isteği için hedef gereklidir.');
+      return;
+    }
+
+    setIsRequestingSignoff(true);
+    setSignoffError(null);
+    try {
+      const response = await requestWorkspaceSignoff({
+        token: trimmedToken,
+        license: trimmedLicense,
+        workspaceId,
+        documentId,
+        revisionId: document.revision.id,
+        requestedFor: target,
+      });
+      setSignoffs((previous) => [...previous, response.signoff]);
+      setShowSignoffModal(false);
+      setSignoffTarget('');
+    } catch (err) {
+      setSignoffError(err instanceof ApiError ? err.message : 'İmza isteği gönderilemedi.');
+    } finally {
+      setIsRequestingSignoff(false);
+    }
+  };
+
+  const revisionSummary = useMemo(() => {
+    if (!document) {
+      return '';
+    }
+    return `Revision ${document.revision.number} • Last updated ${new Date(
+      document.revision.createdAt,
+    ).toLocaleString()}`;
+  }, [document]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Requirements editor"
+        description="Manage requirements, collect feedback and request signoffs without leaving the browser."
+        breadcrumb={[{ label: 'Workspaces', href: '/workspaces' }, { label: 'Requirements editor' }]}
+        actions={
+          <Button onClick={() => setShowSignoffModal(true)} disabled={!document}>
+            Request signoff
+          </Button>
+        }
+      />
+
+      {loading ? (
+        <Skeleton className="h-64 w-full" data-testid="requirements-loading" />
+      ) : error ? (
+        <Alert title="Belge yüklenemedi" description={error} variant="error" />
+      ) : !document ? (
+        <Alert title="Belge bulunamadı" description="Çalışma alanı belgesi okunamadı." variant="warning" />
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]" data-testid="requirements-editor">
+          <div className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-white">{document.title}</h2>
+                <p className="text-sm text-slate-300">{revisionSummary}</p>
+                <p className="text-xs text-slate-400" data-testid="revision-hash">
+                  Hash: {document.revision.hash}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button type="button" variant="secondary" onClick={handleAddRequirement}>
+                  Add requirement
+                </Button>
+                <Button type="button" onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? 'Saving…' : 'Save changes'}
+                </Button>
+              </div>
+            </div>
+
+            {saveError && <Alert title="Kaydetme hatası" description={saveError} variant="error" />}
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-slate-700" data-testid="requirements-grid">
+                <thead>
+                  <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                    <th className="px-3 py-2">ID</th>
+                    <th className="px-3 py-2">Title</th>
+                    <th className="px-3 py-2">Description</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Tags</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-800">
+                  {requirements.map((requirement, index) => {
+                    const idField = `requirement-${index}-id`;
+                    const titleField = `requirement-${index}-title`;
+                    const descriptionField = `requirement-${index}-description`;
+                    const statusField = `requirement-${index}-status`;
+                    const tagsField = `requirement-${index}-tags`;
+                    return (
+                      <tr key={index} className="align-top text-sm text-slate-100">
+                        <td className="px-3 py-2">
+                          <label className="block text-xs text-slate-400" htmlFor={idField}>
+                            Requirement ID {index + 1}
+                          </label>
+                          <Input
+                            id={idField}
+                            value={requirement.id}
+                            onChange={(event) => handleRequirementChange(index, 'id', event.target.value)}
+                          />
+                        </td>
+                        <td className="px-3 py-2">
+                          <label className="block text-xs text-slate-400" htmlFor={titleField}>
+                            Title {index + 1}
+                          </label>
+                          <Input
+                            id={titleField}
+                            value={requirement.title}
+                            onChange={(event) => handleRequirementChange(index, 'title', event.target.value)}
+                          />
+                        </td>
+                        <td className="px-3 py-2">
+                          <label className="block text-xs text-slate-400" htmlFor={descriptionField}>
+                            Description {index + 1}
+                          </label>
+                          <Textarea
+                            id={descriptionField}
+                            rows={3}
+                            value={requirement.description}
+                            onChange={(event) => handleRequirementChange(index, 'description', event.target.value)}
+                          />
+                        </td>
+                        <td className="px-3 py-2">
+                          <label className="block text-xs text-slate-400" htmlFor={statusField}>
+                            Status {index + 1}
+                          </label>
+                          <select
+                            id={statusField}
+                            className="mt-1 w-full rounded border border-slate-700 bg-slate-900 p-2 text-sm"
+                            value={requirement.status}
+                            onChange={(event) => handleRequirementChange(index, 'status', event.target.value as RequirementStatus)}
+                          >
+                            {requirementStatuses.map((status) => (
+                              <option key={status} value={status}>
+                                {status}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                        <td className="px-3 py-2">
+                          <label className="block text-xs text-slate-400" htmlFor={tagsField}>
+                            Tags {index + 1}
+                          </label>
+                          <Input
+                            id={tagsField}
+                            value={serializeTags(requirement.tags)}
+                            placeholder="comma,separated,tags"
+                            onChange={(event) => handleRequirementChange(index, 'tags', event.target.value)}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {requirements.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="px-3 py-6 text-center text-sm text-slate-400">
+                        No requirements defined yet. Use “Add requirement” to start authoring.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <aside className="space-y-6">
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Comments</h3>
+              <div className="space-y-3" data-testid="comment-list">
+                {comments.length === 0 ? (
+                  <p className="text-sm text-slate-400">Henüz yorum eklenmemiş.</p>
+                ) : (
+                  comments.map((comment) => (
+                    <div key={comment.id} className="rounded border border-slate-800 bg-slate-900 p-3">
+                      <p className="text-xs text-slate-400">
+                        {comment.authorId} • {new Date(comment.createdAt).toLocaleString()}
+                      </p>
+                      <p className="mt-2 text-sm text-slate-100">{comment.body}</p>
+                    </div>
+                  ))
+                )}
+              </div>
+              <form className="space-y-2" onSubmit={handleSubmitComment}>
+                <label className="block text-xs uppercase tracking-wide text-slate-400" htmlFor="new-comment">
+                  Add comment
+                </label>
+                <Textarea
+                  id="new-comment"
+                  rows={3}
+                  value={commentDraft}
+                  onChange={(event) => setCommentDraft(event.target.value)}
+                />
+                {commentError && <p className="text-sm text-red-400">{commentError}</p>}
+                <Button type="submit" disabled={isPostingComment}>
+                  {isPostingComment ? 'Posting…' : 'Post comment'}
+                </Button>
+              </form>
+            </section>
+
+            <section className="space-y-3" data-testid="signoff-list">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Signoffs</h3>
+              {signoffs.length === 0 ? (
+                <p className="text-sm text-slate-400">İmza isteği bulunmuyor.</p>
+              ) : (
+                <ul className="space-y-3">
+                  {signoffs.map((signoff) => (
+                    <li key={signoff.id} className="rounded border border-slate-800 bg-slate-900 p-3">
+                      <div className="flex items-center justify-between">
+                        <p className="text-sm text-slate-100">{signoff.requestedFor}</p>
+                        <Badge variant={signoff.status === 'approved' ? 'success' : 'warning'}>{signoff.status}</Badge>
+                      </div>
+                      <p className="mt-1 text-xs text-slate-400">
+                        Requested by {signoff.requestedBy} • {new Date(signoff.createdAt).toLocaleString()}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">Revision hash: {signoff.revisionHash}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {nextCursor && (
+                <p className="text-xs text-slate-500">Daha fazla yorum için sunucudan `nextCursor` ile devam edin.</p>
+              )}
+            </section>
+          </aside>
+        </div>
+      )}
+
+      {showSignoffModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        >
+          <div className="w-full max-w-md space-y-4 rounded border border-slate-700 bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold text-white">Request signoff</h2>
+            <p className="text-sm text-slate-300">
+              Send a signoff request for the current revision ({document?.revision.hash}).
+            </p>
+            <form className="space-y-3" onSubmit={handleSignoffSubmit}>
+              <label className="block text-xs uppercase tracking-wide text-slate-400" htmlFor="signoff-target">
+                Requested for
+              </label>
+              <Input
+                id="signoff-target"
+                value={signoffTarget}
+                onChange={(event) => setSignoffTarget(event.target.value)}
+              />
+              {signoffError && <p className="text-sm text-red-400">{signoffError}</p>}
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="secondary" onClick={() => setShowSignoffModal(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isRequestingSignoff}>
+                  {isRequestingSignoff ? 'Sending…' : 'Send request'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/types/ambient/index.d.ts
+++ b/types/ambient/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'pg-mem';


### PR DESCRIPTION
## Summary
- add a PKCS#11-backed signing path that emits hardware slot metadata and optional attestation evidence alongside manifest signatures
- mock a YubiHSM-style token in signer tests to cover hardware success and missing key failures while preserving existing ledger cases
- document how to configure the packager with pkcs11js, slot selection, and attestation fields in deployment guides

## Testing
- npm run test --workspace @soipack/packager -- security/signer.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d5174c7554832898da890657dd5df7