### PR TITLE
Add Turkish clarity checks and compliance summary endpoint

### DIFF
--- a/docs/compliance-matrix.md
+++ b/docs/compliance-matrix.md
@@ -50,6 +50,27 @@ Fonksiyon her hedef için beklenen artefakt türlerini `EvidenceIndex` ile eşle
 
 Özet bölümünde her durum için sayaçlar tutulur. `warnings` listesi, eksik kanıt bulunan hedefleri kullanıcıya sunar ve aynı mesajlar tablo düzeyindeki girdilerde de saklanır.
 
+## Uyum snapshot'larında bağımsızlık özeti
+
+`generateComplianceSnapshot` çıktısı, bağımsız kanıt eksikliklerini de raporlar. Snapshot yapısındaki `independenceSummary` alanı şu bilgileri içerir:
+
+- `objectives`: Bağımsız kanıtı bulunmayan hedeflerin listesi. Her kayıt, hedefin kimliğini, bağımsızlık seviyesini (`recommended` veya `required`), mevcut durumunu (`covered`/`partial`/`missing`) ve bağımsız kanıtı eksik olan artefakt türlerini içerir.
+- `totals`: Bağımsız kanıt eksikliğinin duruma göre dağılımını (`partial` ve `missing`) sayısal olarak gösterir. Böylece bağımsızlık riskleri raporlama katmanında tek bir bloktan takip edilebilir.
+
+Bu özet, bağımsızlık gereksinimleri bulunan hedeflerde kanıt sağlansa bile bağımsız imza atlanmışsa kullanıcıyı bilgilendirir ve kapanmayan bağımsızlık açıklarını hızlıca tespit etmeye yardımcı olur.
+
+## Sunucu uyum özet API'si
+
+SOIPack Server, kiracıların son uyum kayıtlarını hızlıca tüketebilmesi için `GET /v1/compliance/summary` uç noktasını sunar. Yanıt yapısı şu alanları içerir:
+
+- `computedAt`: Özetin hesaplandığı ISO zaman damgası.
+- `latest`: En güncel uyum kaydının bilgileri ya da hiç kayıt yoksa `null`.
+  - `summary`: Hedeflerin `covered`/`partial`/`missing` dağılımı.
+  - `coverage`: Son kapsam raporundan `statements`/`branches`/`functions`/`lines` yüzdeleri.
+  - `gaps.missingIds` ve `gaps.partialIds`: Kapsaması eksik hedef kimlikleri ve `openObjectiveCount` toplam açık hedef sayısı.
+
+Sonuçlar 60 saniyelik bir önbellekten (`Cache-Control: private, max-age=60`) servis edilir; yeni bir uyum kaydı yüklendiğinde önbellek temizlenir. Böylece paneller her istek için ağır JSON dosyalarını okumadan güncel hedef durumlarını gösterebilir.
+
 ## Veri akışı
 
 1. Dış kaynaklardan gelen kanıtlar `EvidenceIndex` yapısına taşınır.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,11 +1,11 @@
 # Kapsam Toplayıcıları
 
-SOIPack motoru, farklı kapsama çıktılarından birleşik özetler üretmek için `CoverageAggregator` yardımcılarını sağlar. Toplayıcılar statement, dallanma ve MC/DC metriklerini normalize eder, sonuçları `CoverageReport` şemasına dönüştürür ve kullanıcıları eksik veriler konusunda bilgilendirir.
+SOIPack motoru, farklı kapsama çıktılarından birleşik özetler üretmek için `CoverageAggregator` yardımcılarını sağlar. Toplayıcılar statement, fonksiyon, dallanma ve MC/DC metriklerini normalize eder, sonuçları `CoverageReport` şemasına dönüştürür ve kullanıcıları eksik veriler konusunda bilgilendirir.
 
 ## Desteklenen kaynak formatları
 
-- **JSON yapılandırılmış kapsam** – Her dosya için satır, dallanma ve MC/DC girişlerini içeren ayrıntılı bir JSON belgesi kabul edilir. Satır düzeyindeki kayıtlar `hit` alanıyla işaretlenir ve dallanma/MC/DC girdileri kapsanan ve toplam sayıları belirtir.
-- **Cobertura XML** – Standart Cobertura `<coverage>` çıktılarından satır ve karar kapsamı çıkarılır. `condition-coverage="50% (1/2)"` gibi öznitelikler karar kapsam oranlarını belirlemek için ayrıştırılır.
+- **JSON yapılandırılmış kapsam** – Her dosya için satır, fonksiyon, dallanma ve MC/DC girişlerini içeren ayrıntılı bir JSON belgesi kabul edilir. Satır ve fonksiyon kayıtları `hit` alanıyla işaretlenir; dallanma/MC/DC girdileri kapsanan ve toplam sayıları belirtir.
+- **Cobertura XML** – Standart Cobertura `<coverage>` çıktılarından satır, fonksiyon ve karar kapsamı çıkarılır. `condition-coverage="50% (1/2)"` gibi öznitelikler karar kapsam oranlarını belirlemek için ayrıştırılır. Method blokları, satır isabetlerine göre fonksiyon kapsamını hesaplamak için analiz edilir.
 
 Her iki içe aktarım da dosya yollarını normalize eder ve sonuçları motorun diğer bileşenlerinde kullanılan `CoverageReport` tipine dönüştürür. Böylece izlenebilirlik raporları ve kalite kontrolleri tek bir kapsama temsilinden beslenir.
 
@@ -18,8 +18,9 @@ Her iki içe aktarım da dosya yollarını normalize eder ve sonuçları motorun
 Toplayıcılar tüm metrikleri 0,1 hassasiyetinde hesaplar:
 
 1. Her dosyanın satır girişlerinden toplam ve kapsanan satır sayısı çıkarılır.
-2. Dallanma ve MC/DC girdileri varsa toplanır; toplam 0 ise metrikler rapordan çıkarılır.
-3. Dosya metrikleri `covered / total` değerleri kullanılarak yüzdeye çevrilir ve `toFixed(1)` ile yuvarlanır.
+2. Fonksiyon kayıtları, bağımsız `hit` değerleriyle kapsanan fonksiyon sayısını hesaplar.
+3. Dallanma ve MC/DC girdileri varsa toplanır; toplam 0 ise metrikler rapordan çıkarılır.
+4. Dosya metrikleri `covered / total` değerleri kullanılarak yüzdeye çevrilir ve `toFixed(1)` ile yuvarlanır.
 4. Tüm dosyalar üzerinden küresel toplamlar hesaplanır ve aynı hassasiyetle raporlanır.
 
 ## Satır aralıklarının yok sayılması
@@ -28,4 +29,4 @@ Toplayıcı fonksiyonları `ignore` seçeneği ile dosya bazlı satır aralıkla
 
 ## Uyarılar
 
-MC/DC verisi sağlamayan girdiler kullanıcıya açık uyarılar üretir. JSON içe aktarımında MC/DC dizisi olmayan her dosya için bir uyarı döner; Cobertura raporları ise MC/DC desteği sunmadığı için her dosya için ve rapor genelinde ek bilgilendirme mesajları üretir. Toplamlarda MC/DC metriği bulunmuyorsa “MC/DC kapsam verisi raporda bulunamadı.” mesajı eklenir. Bu uyarılar raporlama katmanında görünür ve doğrulama sürecinde eksik metriklerin fark edilmesini sağlar.
+Fonksiyon veya MC/DC verisi sağlamayan girdiler kullanıcıya açık uyarılar üretir. JSON içe aktarımında ilgili diziler eksik olduğunda dosya bazında uyarı döner; Cobertura raporları method bilgisi ya da MC/DC desteği sunmadığında her dosya için ve rapor genelinde ek bilgilendirme mesajları üretilir. Toplamlarda fonksiyon veya MC/DC metriği bulunmuyorsa sırasıyla “Fonksiyon kapsam verisi raporda bulunamadı.” ve “MC/DC kapsam verisi raporda bulunamadı.” mesajları eklenir. Bu uyarılar raporlama katmanında görünür ve doğrulama sürecinde eksik metriklerin fark edilmesini sağlar.

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -104,7 +104,8 @@ Dosya: `packages/adapters/src/qaLogs.ts`
 
 - `importQaLogs(path)` fonksiyonu QA denetim imza CSV'lerini satır bazlı olarak işler.
 - Gerekli sütunlar: `Objective` (veya `Objective ID`) ve `Status`. Opsiyonel sütunlar `Artifact`, `Reviewer`, `Completed At`, `Notes` olarak eşleştirilir.
-- Her satır `qa_record` kanıt özeti üretir; boş satırlar atlanır, eksik sütunlar uyarı olarak döndürülür.
+- Durum değerleri `approved`/`pending`/`rejected` biçiminde normalize edilir; `APPROVED`, `Beklemede`, `Reddedildi`, `in-review` gibi farklı yazımlar aynı kanonik değere eşlenir. Bilinmeyen ifadeler `pending` olarak varsayılır ve uyarı mesajı üretilir.
+- Her satır `qa_record` kanıt özeti üretir; boş satırlar atlanır, eksik sütunlar veya tanınmayan durumlar uyarı olarak döndürülür.
 - CLI `--qa` bayrağıyla verilen dosyaları okuyup QA kayıtlarını A-7 hedeflerine otomatik olarak bağlar.
 
 ## Statik analiz bulguları

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -10,6 +10,7 @@ Analiz şu kontrolleri uygular:
 - **Çelişkili eşleşmeler:** Bağlantılar tek yönlü veya tutarsız olduğunda (örneğin kod bir testi referans eder ancak test aynı kodu doğrulamaz) çatışma kaydı oluşturulur.
 - **Yetim varlıklar:** Hiçbir gereksinimle ilişkilendirilmeyen tasarım ve kod bileşenleri ile herhangi bir kodu doğrulamayan testler işaretlenir.
 - **Geçersiz referanslar:** Modelde bulunmayan kimliklere yapılan atıflar yüksek öncelikli çakışma olarak belirtilir.
+- **Belirsiz dil sezgileri:** Hem İngilizce hem Türkçe metinlerde "TBD", "as appropriate", "olmalı", "gerektiğinde" veya "yeterli" gibi yer tutucu/yorum açık ifadeler algılandığında kalite uyarıları üretilir.
 
 ## Önceliklendirme
 

--- a/packages/adapters/src/__fixtures__/qa-logs/sample.csv
+++ b/packages/adapters/src/__fixtures__/qa-logs/sample.csv
@@ -1,4 +1,4 @@
 Objective,Artifact,Reviewer,Status,Completed At,Notes
-A-7-01,Software Quality Audit,QA Lead,approved,2024-02-10,Checklist complete
-A-7-02,Manufacturing QA Review,QA Lead,approved,2024-02-11,
-A-7-03,,QA Auditor,approved,2024-02-12,Follow-up required
+A-7-01,Software Quality Audit,QA Lead,APPROVED,2024-02-10,Checklist complete
+A-7-02,Manufacturing QA Review,QA Lead,Beklemede,2024-02-11,
+A-7-03,,QA Auditor,Reddedildi,2024-02-12,Follow-up required

--- a/packages/adapters/src/__fixtures__/qa-logs/unknown-status.csv
+++ b/packages/adapters/src/__fixtures__/qa-logs/unknown-status.csv
@@ -1,0 +1,3 @@
+Objective,Status
+A-7-10,Aguardando
+A-7-11,APPROVADO

--- a/packages/adapters/src/qaLogs.test.ts
+++ b/packages/adapters/src/qaLogs.test.ts
@@ -19,11 +19,17 @@ describe('importQaLogs', () => {
         notes: 'Checklist complete',
       }),
     );
+    expect(result.data[1]).toEqual(
+      expect.objectContaining({
+        objectiveId: 'A-7-02',
+        status: 'pending',
+      }),
+    );
     expect(result.data[2]).toEqual(
       expect.objectContaining({
         objectiveId: 'A-7-03',
         reviewer: 'QA Auditor',
-        status: 'approved',
+        status: 'rejected',
         completedAt: '2024-02-12',
         notes: 'Follow-up required',
       }),
@@ -39,6 +45,22 @@ describe('importQaLogs', () => {
       expect.arrayContaining([
         'CSV file is missing an Objective column.',
         'Row 2 is missing an objective id and was skipped.',
+      ]),
+    );
+  });
+
+  it('defaults unknown status values to pending with a warning', async () => {
+    const fixture = path.join(__dirname, '__fixtures__', 'qa-logs', 'unknown-status.csv');
+    const result = await importQaLogs(fixture);
+
+    expect(result.data).toEqual([
+      expect.objectContaining({ objectiveId: 'A-7-10', status: 'pending' }),
+      expect.objectContaining({ objectiveId: 'A-7-11', status: 'pending' }),
+    ]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        'Row 2 has unknown status "Aguardando"; defaulting to "pending". Accepted values: approved/pending/rejected.',
+        'Row 3 has unknown status "APPROVADO"; defaulting to "pending". Accepted values: approved/pending/rejected.',
       ]),
     );
   });

--- a/packages/engine/src/__mocks__/fast-xml-parser.ts
+++ b/packages/engine/src/__mocks__/fast-xml-parser.ts
@@ -1,0 +1,98 @@
+const attributePattern = /([A-Za-z0-9_-]+)="([^"]*)"/g;
+
+const parseAttributes = (source: string): Record<string, string> => {
+  const attributes: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+  while ((match = attributePattern.exec(source)) !== null) {
+    attributes[match[1]] = match[2];
+  }
+  return attributes;
+};
+
+const parseLineNodes = (content: string): Array<Record<string, string>> => {
+  const lines: Array<Record<string, string>> = [];
+  const lineRegex = /<line([^>]*)\/>/g;
+  let match: RegExpExecArray | null;
+  while ((match = lineRegex.exec(content)) !== null) {
+    lines.push(parseAttributes(match[1]));
+  }
+  return lines;
+};
+
+const parseMethods = (
+  content: string,
+): Array<Record<string, unknown>> | undefined => {
+  const methodsSection = content.match(/<methods>([\s\S]*?)<\/methods>/);
+  if (!methodsSection) {
+    return undefined;
+  }
+  const methodsContent = methodsSection[1];
+  const methodRegex = /<method([^>]*)>([\s\S]*?)<\/method>/g;
+  const methods: Array<Record<string, unknown>> = [];
+  let match: RegExpExecArray | null;
+  while ((match = methodRegex.exec(methodsContent)) !== null) {
+    const attributes = parseAttributes(match[1]);
+    const linesBlock = match[2].match(/<lines>([\s\S]*?)<\/lines>/);
+    const lineNodes = linesBlock ? parseLineNodes(linesBlock[1]) : [];
+    methods.push({ ...attributes, lines: { line: lineNodes } });
+  }
+  return methods.length > 0 ? methods : undefined;
+};
+
+const parseClasses = (content: string): Array<Record<string, unknown>> => {
+  const classes: Array<Record<string, unknown>> = [];
+  const classRegex = /<class([^>]*)>([\s\S]*?)<\/class>/g;
+  let match: RegExpExecArray | null;
+  while ((match = classRegex.exec(content)) !== null) {
+    const attributes = parseAttributes(match[1]);
+    const body = match[2];
+    const methods = parseMethods(body);
+    const bodyWithoutMethods = body.replace(/<methods>[\s\S]*?<\/methods>/g, '');
+    const linesBlock = bodyWithoutMethods.match(/<lines>([\s\S]*?)<\/lines>/);
+    const lineNodes = linesBlock ? parseLineNodes(linesBlock[1]) : [];
+    const entry: Record<string, unknown> = {
+      ...attributes,
+      lines: { line: lineNodes },
+    };
+    if (methods) {
+      entry.methods = { method: methods };
+    }
+    classes.push(entry);
+  }
+  return classes;
+};
+
+const parsePackages = (xml: string): Array<Record<string, unknown>> => {
+  const packagesSection = xml.match(/<packages>([\s\S]*?)<\/packages>/);
+  if (!packagesSection) {
+    return [];
+  }
+  const packagesContent = packagesSection[1];
+  const packageRegex = /<package([^>]*)>([\s\S]*?)<\/package>/g;
+  const packages: Array<Record<string, unknown>> = [];
+  let match: RegExpExecArray | null;
+  while ((match = packageRegex.exec(packagesContent)) !== null) {
+    const attributes = parseAttributes(match[1]);
+    const body = match[2];
+    const classesSection = body.match(/<classes>([\s\S]*?)<\/classes>/);
+    const classes = classesSection ? parseClasses(classesSection[1]) : [];
+    packages.push({ ...attributes, classes: { class: classes } });
+  }
+  return packages;
+};
+
+export class XMLParser {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_options?: unknown) {}
+
+  parse(xml: string): Record<string, unknown> {
+    const packages = parsePackages(xml);
+    return {
+      coverage: {
+        packages: {
+          package: packages,
+        },
+      },
+    };
+  }
+}

--- a/packages/engine/src/coverage.test.ts
+++ b/packages/engine/src/coverage.test.ts
@@ -1,3 +1,5 @@
+jest.mock('fast-xml-parser');
+
 import { aggregateCoberturaCoverage, aggregateJsonCoverage } from './coverage';
 
 describe('CoverageAggregator', () => {
@@ -16,6 +18,10 @@ describe('CoverageAggregator', () => {
               { line: 2, covered: 1, total: 2 },
               { line: 3, covered: 2, total: 2 },
             ],
+            functions: [
+              { line: 1, hit: 1 },
+              { line: 5, hit: 0 },
+            ],
             mcdc: [
               { line: 6, covered: 2, total: 4 },
             ],
@@ -24,6 +30,9 @@ describe('CoverageAggregator', () => {
             path: 'src/services/audit.ts',
             statements: [
               { line: 10, hit: 1 },
+              { line: 11, hit: 0 },
+            ],
+            functions: [
               { line: 11, hit: 0 },
             ],
           },
@@ -41,17 +50,22 @@ describe('CoverageAggregator', () => {
 
     expect(auth.statements).toEqual({ covered: 2, total: 3, percentage: 66.7 });
     expect(auth.branches).toEqual({ covered: 3, total: 4, percentage: 75 });
+    expect(auth.functions).toEqual({ covered: 1, total: 2, percentage: 50 });
     expect(auth.mcdc).toEqual({ covered: 2, total: 4, percentage: 50 });
 
     expect(audit.statements).toEqual({ covered: 1, total: 1, percentage: 100 });
     expect(audit.branches).toBeUndefined();
+    expect(audit.functions).toBeUndefined();
     expect(audit.mcdc).toBeUndefined();
 
     expect(result.summary.totals.statements).toEqual({ covered: 3, total: 4, percentage: 75 });
+    expect(result.summary.totals.functions).toEqual({ covered: 1, total: 2, percentage: 50 });
     expect(result.summary.totals.mcdc).toEqual({ covered: 2, total: 4, percentage: 50 });
 
     expect(result.warnings).toContain('MC/DC kapsam verisi eksik: src/services/audit.ts');
+    expect(result.warnings).toContain('Fonksiyon kapsam verisi eksik: src/services/audit.ts');
     expect(result.warnings).not.toContain('MC/DC kapsam verisi raporda bulunamadı.');
+    expect(result.warnings).not.toContain('Fonksiyon kapsam verisi raporda bulunamadı.');
   });
 
   it('parses Cobertura XML and reports branch and MC/DC warnings', () => {
@@ -61,6 +75,20 @@ describe('CoverageAggregator', () => {
     <package name="core">
       <classes>
         <class name="Auth" filename="src/auth.ts">
+          <methods>
+            <method name="authenticate" signature="()V">
+              <lines>
+                <line number="1" hits="1" />
+                <line number="2" hits="0" />
+              </lines>
+            </method>
+            <method name="logout" signature="()V">
+              <lines>
+                <line number="3" hits="1" branch="true" condition-coverage="100% (2/2)" />
+                <line number="4" hits="0" />
+              </lines>
+            </method>
+          </methods>
           <lines>
             <line number="1" hits="1" />
             <line number="2" hits="0" branch="true" condition-coverage="50% (1/2)" />
@@ -90,22 +118,27 @@ describe('CoverageAggregator', () => {
 
     expect(auth.statements).toEqual({ covered: 2, total: 4, percentage: 50 });
     expect(auth.branches).toEqual({ covered: 3, total: 4, percentage: 75 });
+    expect(auth.functions).toEqual({ covered: 2, total: 2, percentage: 100 });
     expect(auth.mcdc).toBeUndefined();
 
     expect(audit.statements).toEqual({ covered: 1, total: 1, percentage: 100 });
     expect(audit.branches).toBeUndefined();
+    expect(audit.functions).toBeUndefined();
 
     expect(result.summary.totals.statements).toEqual({ covered: 3, total: 5, percentage: 60 });
     expect(result.summary.totals.branches).toEqual({ covered: 3, total: 4, percentage: 75 });
+    expect(result.summary.totals.functions).toEqual({ covered: 2, total: 2, percentage: 100 });
     expect(result.summary.totals.mcdc).toBeUndefined();
 
     expect(result.warnings).toEqual(
       expect.arrayContaining([
         'Karar kapsamı verisi bulunamadı: src/audit.ts',
+        'Fonksiyon kapsam verisi eksik: src/audit.ts',
         'MC/DC kapsam verisi eksik: src/auth.ts',
         'MC/DC kapsam verisi eksik: src/audit.ts',
         'MC/DC kapsam verisi raporda bulunamadı.',
       ]),
     );
+    expect(result.warnings).not.toContain('Fonksiyon kapsam verisi raporda bulunamadı.');
   });
 });

--- a/packages/engine/src/quality.test.ts
+++ b/packages/engine/src/quality.test.ts
@@ -1,0 +1,62 @@
+import { evaluateQualityFindings } from './quality';
+import type { RequirementTrace } from './index';
+
+describe('evaluateQualityFindings - clarity heuristics', () => {
+  const createTrace = (requirement: RequirementTrace['requirement']): RequirementTrace => ({
+    requirement,
+    tests: [],
+    code: [],
+    designs: [],
+  });
+
+  it('flags English and Turkish ambiguity cues within the same requirement', () => {
+    const requirement = {
+      id: 'REQ-TR-CLAR',
+      title:
+        'SİSTEM OLMALI ve GEREKTİĞİNDE destek moduna geçerek as appropriate prosedürlerini tetikleyecektir.',
+      description: 'Operasyon YETERLİ hata toleransı bırakmalıdır.',
+      status: 'draft' as const,
+      tags: [],
+    };
+
+    const findings = evaluateQualityFindings([createTrace(requirement)], [], []);
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'REQ-TR-CLAR-clarity-should-olmali',
+          severity: 'warn',
+          category: 'analysis',
+        }),
+        expect.objectContaining({
+          id: 'REQ-TR-CLAR-clarity-as-needed-gerektiginde',
+          severity: 'warn',
+          category: 'analysis',
+        }),
+        expect.objectContaining({
+          id: 'REQ-TR-CLAR-clarity-subjective-adjective',
+          severity: 'warn',
+          category: 'analysis',
+        }),
+        expect.objectContaining({
+          id: 'REQ-TR-CLAR-clarity-as-appropriate',
+          severity: 'warn',
+          category: 'analysis',
+        }),
+      ]),
+    );
+  });
+
+  it('does not report clarity warnings when requirement text is precise', () => {
+    const requirement = {
+      id: 'REQ-TR-CLEAR',
+      title: 'Sistem, 5 saniye içinde otomatik moda geçer ve operatöre durum mesajı gönderir.',
+      status: 'draft' as const,
+      tags: [],
+    };
+
+    const findings = evaluateQualityFindings([createTrace(requirement)], [], []);
+
+    expect(findings.filter((finding) => finding.id.includes('clarity-'))).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/quality.ts
+++ b/packages/engine/src/quality.ts
@@ -38,7 +38,21 @@ const ambiguousLanguagePatterns: Array<{
   { id: 'as-necessary', regex: /\bas (?:necessary|required)\b/i, phraseFromMatch: true },
   { id: 'be-able-to', regex: /\bbe able to\b/i, phrase: '"be able to"' },
   { id: 'etc', regex: /\betc\./i, phrase: '"etc."' },
-  { id: 'subjective-adjective', regex: /\b(adequate|sufficient|minimal|flexible)\b/i, phraseFromMatch: true },
+  {
+    id: 'should-olmali',
+    regex: /(?<![A-Za-zÇĞİÖŞÜçğıöşü])olmal[ıi](?![A-Za-zÇĞİÖŞÜçğıöşü])/iu,
+    phraseFromMatch: true,
+  },
+  {
+    id: 'as-needed-gerektiginde',
+    regex: /(?<![A-Za-zÇĞİÖŞÜçğıöşü])gerekti(?:ğ|g)inde(?![A-Za-zÇĞİÖŞÜçğıöşü])/iu,
+    phraseFromMatch: true,
+  },
+  {
+    id: 'subjective-adjective',
+    regex: /(?<![A-Za-zÇĞİÖŞÜçğıöşü])(adequate|sufficient|minimal|flexible|yeterli)(?![A-Za-zÇĞİÖŞÜçğıöşü])/iu,
+    phraseFromMatch: true,
+  },
 ];
 
 const passiveVoicePattern = /\b(?:shall|will|must|should)\s+be\s+\w+(?:ed|en)\b/i;
@@ -141,8 +155,10 @@ const evaluateRequirementClarity = (requirement: Requirement): QualityFinding[] 
 
   const findings: QualityFinding[] = [];
 
+  const normalizedText = text.toLocaleLowerCase('tr-TR');
+
   ambiguousLanguagePatterns.forEach((pattern) => {
-    const match = text.match(pattern.regex);
+    const match = text.match(pattern.regex) ?? normalizedText.match(pattern.regex);
     if (!match) {
       return;
     }

--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -491,6 +491,108 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JobSummary'
+    ComplianceCoverageSnapshot:
+      type: object
+      description: Kapsam yüzdeleri. Sağlanan değerler üç ondalık hassasiyete yuvarlanır.
+      additionalProperties: false
+      properties:
+        statements:
+          type: number
+          format: double
+          minimum: 0
+        branches:
+          type: number
+          format: double
+          minimum: 0
+        functions:
+          type: number
+          format: double
+          minimum: 0
+        lines:
+          type: number
+          format: double
+          minimum: 0
+    ComplianceGapSummary:
+      type: object
+      required:
+        - missingIds
+        - partialIds
+        - openObjectiveCount
+      properties:
+        missingIds:
+          type: array
+          description: Kanıt bulunmayan hedef kimlikleri.
+          items:
+            type: string
+        partialIds:
+          type: array
+          description: Kapsaması kısmi olan hedef kimlikleri.
+          items:
+            type: string
+        openObjectiveCount:
+          type: integer
+          minimum: 0
+          description: missingIds ve partialIds toplamı.
+    ComplianceSummaryLatest:
+      type: object
+      required:
+        - id
+        - createdAt
+        - summary
+        - coverage
+        - gaps
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        project:
+          type: string
+          nullable: true
+        level:
+          type: string
+          nullable: true
+        generatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        summary:
+          type: object
+          required:
+            - total
+            - covered
+            - partial
+            - missing
+          properties:
+            total:
+              type: integer
+              minimum: 0
+            covered:
+              type: integer
+              minimum: 0
+            partial:
+              type: integer
+              minimum: 0
+            missing:
+              type: integer
+              minimum: 0
+        coverage:
+          $ref: '#/components/schemas/ComplianceCoverageSnapshot'
+        gaps:
+          $ref: '#/components/schemas/ComplianceGapSummary'
+    ComplianceSummaryResponse:
+      type: object
+      required:
+        - computedAt
+        - latest
+      properties:
+        computedAt:
+          type: string
+          format: date-time
+        latest:
+          $ref: '#/components/schemas/ComplianceSummaryLatest'
+          nullable: true
     ComplianceRiskBreakdownEntry:
       type: object
       required: [factor, contribution, weight, details]
@@ -2135,6 +2237,42 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/compliance/summary:
+    get:
+      operationId: getComplianceSummary
+      summary: Son uyum matrisinin özetini ve kapsam metriklerini döner.
+      description: |
+        En güncel uyum kaydının hedef sayıları, kapsam yüzdeleri ve açık hedef
+        listelerini döndürür. Yanıtlar 60 saniyelik bir önbellekten servis
+        edilir ve `Cache-Control: private, max-age=60` başlığı içerir.
+      tags:
+        - Compliance
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Uyum özeti başarıyla getirildi.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: Özet sonucunun önbellek süresi.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceSummaryResponse'
+        '401':
+          description: Kimlik doğrulama başarısız.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: İstemci gerekli role sahip değil.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- extend the quality analysis heuristics to flag Turkish ambiguity phrases alongside English cues with new bilingual tests and documentation
- normalize QA log statuses into approved/pending/rejected (including localized aliases), update fixtures/tests/docs, and restore latin-1 accents in the DOORS sample
- add a cached GET /v1/compliance/summary endpoint with OpenAPI/docs updates and integration coverage for the new compliance summary payload

## Testing
- npm run test --workspace @soipack/engine
- npm run test --workspace @soipack/adapters
- npm run test --workspace @soipack/server
- npm run openapi:validate

------
https://chatgpt.com/codex/tasks/task_b_68d7f14e79a08328b83f95f7bd92484f