### PR TITLE
feat: surface backlog contributions in risk streaming

### DIFF
--- a/packages/server/src/events.test.ts
+++ b/packages/server/src/events.test.ts
@@ -3,7 +3,7 @@ import { Writable } from 'stream';
 import type { Request, Response } from 'express';
 
 import type { LedgerEntry } from '@soipack/core';
-import type { RiskProfile } from '@soipack/engine';
+import type { ComplianceRiskFactorContributions, RiskProfile } from '@soipack/engine';
 
 import type { JobSummary } from './queue';
 import { ComplianceEventStream, EventAuthorizationError } from './events';
@@ -75,7 +75,17 @@ describe('ComplianceEventStream', () => {
       missingSignals: [],
     };
 
-    stream.publishRiskProfile(tenantId, profile, { id: 'risk-1', emittedAt: '2024-08-01T10:00:00Z' });
+    const contributions: ComplianceRiskFactorContributions = {
+      coverageDrift: 12,
+      testFailures: 7,
+      backlogSeverity: 5,
+    };
+
+    stream.publishRiskProfile(tenantId, profile, {
+      id: 'risk-1',
+      emittedAt: '2024-08-01T10:00:00Z',
+      contributions,
+    });
 
     const ledgerEntry: LedgerEntry = {
       index: 1,
@@ -119,6 +129,7 @@ describe('ComplianceEventStream', () => {
     expect(riskData.type).toBe('riskProfile');
     expect(riskData.tenantId).toBe(tenantId);
     expect(riskData.profile).toMatchObject({ score: 42, classification: 'moderate' });
+    expect(riskData.contributions).toEqual(contributions);
 
     const ledgerData = parseData(ledgerChunk);
     expect(ledgerData.type).toBe('ledgerEntry');


### PR DESCRIPTION
## Summary
- include compliance risk factor contributions in server-sent risk events with default values
- fetch and cache Jira backlog metrics during risk refresh to emit contribution maps through SSE
- expose risk refresh helpers in the server lifecycle and cover Jira success/fallback paths in tests

## Testing
- npm run test --workspace @soipack/server -- events.test.ts
- npm run test --workspace @soipack/server -- index.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68daca1a645c8328b16b42bceb2a060b